### PR TITLE
Use consistent k8s API semver comparison logic

### DIFF
--- a/charts/opensearch-dashboards/templates/ingress.yaml
+++ b/charts/opensearch-dashboards/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-  {{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
+  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:


### PR DESCRIPTION
### Description
This is required to work around bugs in the version string returned by
kubernetes distros such as EKS and GKE, where they have invalid Semantic
Version strings. See https://github.com/helm/helm/issues/3810.
 
### Issues Resolved
Closes: #34 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
