### PR TITLE
Remove buggy labels template

### DIFF
--- a/charts/opensearch-dashboards/templates/_helpers.tpl
+++ b/charts/opensearch-dashboards/templates/_helpers.tpl
@@ -60,14 +60,3 @@ Create the name of the service account to use
     {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
-
-{{/*
-Define standard labels for frequently used metadata.
-*/}}
-{{- define "opensearch-dashboards.standard" -}}
-app: {{ template "opensearch-dashboards.fullname" . }}
-chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-release: "{{ .Release.Name }}"
-heritage: "{{ .Release.Service }}"
-{{- end -}}
-

--- a/charts/opensearch-dashboards/templates/rolebinding.yaml
+++ b/charts/opensearch-dashboards/templates/rolebinding.yaml
@@ -2,8 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-{{ include "opensearch-dashboards.standard" . | indent 4 }}
+  labels: {{- include "opensearch-dashboards.labels" . | nindent 4 }}
   name: {{ template "opensearch-dashboards.fullname" . }}-dashboards-rolebinding
 roleRef:
   kind: Role


### PR DESCRIPTION
### Description
The opensearch-dashboards.standard did not properly escape chart
version, and anyway we should be using the same set of standard labels
as all the other templates.
 
### Issues Resolved
Closes: #33
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
