### PR TITLE
Modify majorVersion fallback logic

### DIFF
--- a/charts/opensearch/templates/_helpers.tpl
+++ b/charts/opensearch/templates/_helpers.tpl
@@ -55,7 +55,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- if .Values.majorVersion }}
   {{- .Values.majorVersion }}
 {{- else }}
-  {{- $version := semver (coalesce .Values.imageTag .Chart.AppVersion "7") }}
+  {{- $version := semver (coalesce .Values.imageTag .Chart.AppVersion "1") }}
   {{- $version.Major }}
 {{- end }}
 {{- end }}

--- a/charts/opensearch/templates/_helpers.tpl
+++ b/charts/opensearch/templates/_helpers.tpl
@@ -52,14 +52,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "opensearch.majorVersion" -}}
-{{- if .Values.majorVersion -}}
-{{ .Values.majorVersion }}
-{{- else -}}
-{{- $version := int (index (.Values.imageTag | splitList ".") 0) -}}
-  {{- if and (contains "opensearchproject/opensearch" .Values.image) (not (eq $version 0)) -}}
-{{ $version }}
-  {{- else -}}
-7
-  {{- end -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.majorVersion }}
+  {{- .Values.majorVersion }}
+{{- else }}
+  {{- $version := semver (coalesce .Values.imageTag .Chart.AppVersion "7") }}
+  {{- $version.Major }}
+{{- end }}
+{{- end }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -17,6 +17,7 @@ roles:
 replicas: 3
 minimumMasterNodes: 1
 
+# if not set, falls back to parsing .Values.imageTag, then .Chart.appVersion.
 majorVersion: ""
 
 # Allows you to add any config files in {{ .Values.configPath }}/config


### PR DESCRIPTION
### Description
* Look in both .Values.imageTag and .Chart.AppVersion before falling
back to a default value.
* Use the built-in semver parsing function.
* Don't ignore the version for non-opensearch images.
 
### Issues Resolved
Closes: #32 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
