### PR TITLE
Use consistent indentation in opensearch templates

### DIFF
--- a/charts/opensearch/templates/networkpolicy.yaml
+++ b/charts/opensearch/templates/networkpolicy.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "opensearch.uname" . }}-opensearch-net
 spec:
   ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              {{ template "opensearch.uname" . }}-transport-client: "true"
+  - from:
+    - podSelector:
+        matchLabels:
+          {{ template "opensearch.uname" . }}-transport-client: "true"
   podSelector:
     matchLabels:
       {{ template "opensearch.uname" . }}-transport-client: "true"

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       accessModes:
       {{- range .Values.persistence.accessModes }}
-        - {{ . | quote }}
+      - {{ . | quote }}
       {{- end }}
       resources:
         requests:
@@ -83,8 +83,8 @@ spec:
 {{ toYaml .Values.podSecurityContext | indent 8 }}
         {{- if .Values.sysctl.enabled }}
         sysctls:
-          - name: vm.max_map_count
-            value: {{ .Values.sysctlVmMaxMapCount | quote }}
+        - name: vm.max_map_count
+          value: {{ .Values.sysctlVmMaxMapCount | quote }}
         {{- end }}
         {{- if .Values.fsGroup }}
         fsGroup: {{ .Values.fsGroup }} # Deprecated value, please use .Values.podSecurityContext.fsGroup
@@ -137,70 +137,70 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriod }}
       volumes:
-        {{- range .Values.secretMounts }}
-        - name: {{ .name }}
-          secret:
-            secretName: {{ .secretName }}
-            {{- if .defaultMode }}
-            defaultMode: {{ .defaultMode }}
-            {{- end }}
-        {{- end }}
-        {{- if .Values.config }}
-        - name: config
-          configMap:
-            name: {{ template "opensearch.uname" . }}-config
-        {{- end }}
-        {{- if and .Values.securityConfig.config.securityConfigSecret .Values.securityConfig.config.data }}
-        - name: security-config
-          secret:
-           secretName: {{ .Values.securityConfig.config.securityConfigSecret }}
-        {{- end }}
-        {{- if .Values.securityConfig.actionGroupsSecret }}
-        - name: action-groups
-          secret:
-            secretName: {{ .Values.securityConfig.actionGroupsSecret }}
-        {{- end }}
-        {{- if .Values.securityConfig.configSecret }}
-        - name: security-config
-          secret:
-            secretName: {{ .Values.securityConfig.configSecret }}
-        {{- end }}
-        {{- if .Values.securityConfig.internalUsersSecret }}
-        - name: internal-users-config
-          secret:
-            secretName: {{ .Values.securityConfig.internalUsersSecret }}
-        {{- end }}
-        {{- if .Values.securityConfig.rolesSecret }}
-        - name: roles
-          secret:
-            secretName: {{ .Values.securityConfig.rolesSecret }}
-        {{- end }}
-        {{- if .Values.securityConfig.rolesMappingSecret }}
-        - name: role-mapping
-          secret:
-            secretName: {{ .Values.securityConfig.rolesMappingSecret }}
-        {{- end -}}
-        {{- if .Values.securityConfig.tenantsSecret }}
-        - name: tenants
-          secret:
-            secretName: {{ .Values.securityConfig.tenantsSecret }}
-        {{- end }}
+      {{- range .Values.secretMounts }}
+      - name: {{ .name }}
+        secret:
+          secretName: {{ .secretName }}
+          {{- if .defaultMode }}
+          defaultMode: {{ .defaultMode }}
+          {{- end }}
+      {{- end }}
+      {{- if .Values.config }}
+      - name: config
+        configMap:
+          name: {{ template "opensearch.uname" . }}-config
+      {{- end }}
+      {{- if and .Values.securityConfig.config.securityConfigSecret .Values.securityConfig.config.data }}
+      - name: security-config
+        secret:
+         secretName: {{ .Values.securityConfig.config.securityConfigSecret }}
+      {{- end }}
+      {{- if .Values.securityConfig.actionGroupsSecret }}
+      - name: action-groups
+        secret:
+          secretName: {{ .Values.securityConfig.actionGroupsSecret }}
+      {{- end }}
+      {{- if .Values.securityConfig.configSecret }}
+      - name: security-config
+        secret:
+          secretName: {{ .Values.securityConfig.configSecret }}
+      {{- end }}
+      {{- if .Values.securityConfig.internalUsersSecret }}
+      - name: internal-users-config
+        secret:
+          secretName: {{ .Values.securityConfig.internalUsersSecret }}
+      {{- end }}
+      {{- if .Values.securityConfig.rolesSecret }}
+      - name: roles
+        secret:
+          secretName: {{ .Values.securityConfig.rolesSecret }}
+      {{- end }}
+      {{- if .Values.securityConfig.rolesMappingSecret }}
+      - name: role-mapping
+        secret:
+          secretName: {{ .Values.securityConfig.rolesMappingSecret }}
+      {{- end -}}
+      {{- if .Values.securityConfig.tenantsSecret }}
+      - name: tenants
+        secret:
+          secretName: {{ .Values.securityConfig.tenantsSecret }}
+      {{- end }}
 {{- if .Values.keystore }}
-        - name: keystore
-          emptyDir: {}
-        {{- range .Values.keystore }}
-        - name: keystore-{{ .secretName }}
-          secret: {{ toYaml . | nindent 12 }}
-        {{- end }}
+      - name: keystore
+        emptyDir: {}
+      {{- range .Values.keystore }}
+      - name: keystore-{{ .secretName }}
+        secret: {{ toYaml . | nindent 12 }}
+      {{- end }}
 {{ end }}
       {{- if .Values.extraVolumes }}
       # Currently some extra blocks accept strings
       # to continue with backwards compatibility this is being kept
       # whilst also allowing for yaml to be specified too.
       {{- if eq "string" (printf "%T" .Values.extraVolumes) }}
-{{ tpl .Values.extraVolumes . | indent 8 }}
+{{ tpl .Values.extraVolumes . | indent 6 }}
       {{- else }}
-{{ toYaml .Values.extraVolumes | indent 8 }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
       {{- end }}
       {{- end }}
       {{- if .Values.imagePullSecrets }}
@@ -243,12 +243,12 @@ spec:
         envFrom: {{ toYaml .Values.envFrom | nindent 10 }}
         resources: {{ toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
-          - name: keystore
-            mountPath: /tmp/keystore
-          {{- range .Values.keystore }}
-          - name: keystore-{{ .secretName }}
-            mountPath: /tmp/keystoreSecrets/{{ .secretName }}
-          {{- end }}
+        - name: keystore
+          mountPath: /tmp/keystore
+        {{- range .Values.keystore }}
+        - name: keystore-{{ .secretName }}
+          mountPath: /tmp/keystoreSecrets/{{ .secretName }}
+        {{- end }}
 {{ end }}
       {{- if .Values.extraInitContainers }}
       # Currently some extra blocks accept strings
@@ -275,36 +275,36 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:
-          - name: node.name
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          {{- if eq .Values.roles.master "true" }}
-          {{- if ge (int (include "opensearch.majorVersion" .)) 7 }}
-          - name: cluster.initial_master_nodes
-            value: "{{ template "opensearch.endpoints" . }}"
-          {{- else }}
-          - name: discovery.zen.minimum_master_nodes
-            value: "{{ .Values.minimumMasterNodes }}"
-          {{- end }}
-          {{- end }}
-          {{- if lt (int (include "opensearch.majorVersion" .)) 7 }}
-          - name: discovery.zen.ping.unicast.hosts
-            value: "{{ template "opensearch.masterService" . }}-headless"
-          {{- else }}
-          - name: discovery.seed_hosts
-            value: "{{ template "opensearch.masterService" . }}-headless"
-          {{- end }}
-          - name: cluster.name
-            value: "{{ .Values.clusterName }}"
-          - name: network.host
-            value: "{{ .Values.networkHost }}"
-          - name: ES_JAVA_OPTS
-            value: "{{ .Values.esJavaOpts }}"
-          {{- range $role, $enabled := .Values.roles }}
-          - name: node.{{ $role }}
-            value: "{{ $enabled }}"
-          {{- end }}
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        {{- if eq .Values.roles.master "true" }}
+        {{- if ge (int (include "opensearch.majorVersion" .)) 7 }}
+        - name: cluster.initial_master_nodes
+          value: "{{ template "opensearch.endpoints" . }}"
+        {{- else }}
+        - name: discovery.zen.minimum_master_nodes
+          value: "{{ .Values.minimumMasterNodes }}"
+        {{- end }}
+        {{- end }}
+        {{- if lt (int (include "opensearch.majorVersion" .)) 7 }}
+        - name: discovery.zen.ping.unicast.hosts
+          value: "{{ template "opensearch.masterService" . }}-headless"
+        {{- else }}
+        - name: discovery.seed_hosts
+          value: "{{ template "opensearch.masterService" . }}-headless"
+        {{- end }}
+        - name: cluster.name
+          value: "{{ .Values.clusterName }}"
+        - name: network.host
+          value: "{{ .Values.networkHost }}"
+        - name: ES_JAVA_OPTS
+          value: "{{ .Values.esJavaOpts }}"
+        {{- range $role, $enabled := .Values.roles }}
+        - name: node.{{ $role }}
+          value: "{{ $enabled }}"
+        {{- end }}
 {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 10 }}
 {{- end }}
@@ -313,64 +313,63 @@ spec:
 {{ toYaml .Values.envFrom | indent 10 }}
 {{- end }}
         volumeMounts:
-          {{- if .Values.persistence.enabled }}
-          - name: "{{ template "opensearch.uname" . }}"
-            mountPath: {{ .Values.opensearchHome }}/data
+        {{- if .Values.persistence.enabled }}
+        - name: "{{ template "opensearch.uname" . }}"
+          mountPath: {{ .Values.opensearchHome }}/data
+        {{- end }}
+        {{- if .Values.keystore }}
+        - name: keystore
+          mountPath: {{ .Values.opensearchHome }}/config/opensearch.keystore
+          subPath: opensearch.keystore
+        {{- end }}
+        {{- if .Values.securityConfig.enabled }}
+        {{- if .Values.securityConfig.actionGroupsSecret }}
+        - mountPath: {{ .Values.securityConfig.path }}/action_groups.yml
+          name: action-groups
+          subPath: action_groups.yml
+        {{- end }}
+        {{- if .Values.securityConfig.configSecret }}
+        - mountPath: {{ .Values.securityConfig.path }}/config.yml
+          name: security-config
+          subPath: config.yml
+        {{- end }}
+        {{- if .Values.securityConfig.internalUsersSecret }}
+        - mountPath: {{ .Values.securityConfig.path }}/internal_users.yml
+          name: internal-users-config
+          subPath: internal_users.yml
+        {{- end }}
+        {{- if .Values.securityConfig.rolesSecret }}
+        - mountPath: {{ .Values.securityConfig.path }}/roles.yml
+          name: roles
+          subPath: roles.yml
+        {{- end }}
+        {{- if .Values.securityConfig.rolesMappingSecret }}
+        - mountPath: {{ .Values.securityConfig.path }}/roles_mapping.yml
+          name: role-mapping
+          subPath: roles_mapping.yml
+        {{- end }}
+        {{- if .Values.securityConfig.tenantsSecret }}
+        - mountPath: {{ .Values.securityConfig.path }}/tenants.yml
+          name: tenants
+          subPath: tenants.yml
+        {{- end }}
+        {{- if and .Values.securityConfig.config.securityConfigSecret .Values.securityConfig.config.data  }}
+        - mountPath: {{ .Values.securityConfig.path }}
+          name: security-config
+        {{- end }}
+        {{- end }}
+        {{- range .Values.secretMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .path }}
+          {{- if .subPath }}
+          subPath: {{ .subPath }}
           {{- end }}
-          {{- if .Values.keystore }}
-          - name: keystore
-            mountPath: {{ .Values.opensearchHome }}/config/opensearch.keystore
-            subPath: opensearch.keystore
-          {{- end }}
-          {{- if .Values.securityConfig.enabled }}
-          {{- if .Values.securityConfig.actionGroupsSecret }}
-          - mountPath: {{ .Values.securityConfig.path }}/action_groups.yml
-            name: action-groups
-            subPath: action_groups.yml
-          {{- end }}
-          {{- if .Values.securityConfig.configSecret }}
-          - mountPath: {{ .Values.securityConfig.path }}/config.yml
-            name: security-config
-            subPath: config.yml
-          {{- end }}
-          {{- if .Values.securityConfig.internalUsersSecret }}
-          - mountPath: {{ .Values.securityConfig.path }}/internal_users.yml
-            name: internal-users-config
-            subPath: internal_users.yml
-          {{- end }}
-          {{- if .Values.securityConfig.rolesSecret }}
-          - mountPath: {{ .Values.securityConfig.path }}/roles.yml
-            name: roles
-            subPath: roles.yml
-          {{- end }}
-          {{- if .Values.securityConfig.rolesMappingSecret }}
-          - mountPath: {{ .Values.securityConfig.path }}/roles_mapping.yml
-            name: role-mapping
-            subPath: roles_mapping.yml
-          {{- end }}
-          {{- if .Values.securityConfig.tenantsSecret }}
-          - mountPath: {{ .Values.securityConfig.path }}/tenants.yml
-            name: tenants
-            subPath: tenants.yml
-          {{- end }}
-          {{- if and .Values.securityConfig.config.securityConfigSecret .Values.securityConfig.config.data  }}
-          - mountPath: {{ .Values.securityConfig.path }}
-            name: security-config
-          {{- end }}
-          {{- end }}
-
-          {{- range .Values.secretMounts }}
-          - name: {{ .name }}
-            mountPath: {{ .path }}
-            {{- if .subPath }}
-            subPath: {{ .subPath }}
-            {{- end }}
-          {{- end }}
-          {{- range $path, $config := .Values.config }}
-          - name: config
-            mountPath: {{ $.Values.opensearchHome }}/config/{{ $path }}
-            subPath: {{ $path }}
-          {{- end -}}
+        {{- end }}
+        {{- range $path, $config := .Values.config }}
+        - name: config
+          mountPath: {{ $.Values.opensearchHome }}/config/{{ $path }}
+          subPath: {{ $path }}
+        {{- end -}}
         {{- if .Values.extraVolumeMounts }}
         # Currently some extra blocks accept strings
         # to continue with backwards compatibility this is being kept
@@ -425,16 +424,16 @@ spec:
         resources:
 {{ toYaml .Values.sidecarResources | indent 10 }}
         env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         {{- if .Values.extraEnvs }}
-{{ toYaml .Values.extraEnvs | indent 10 }}
+{{ toYaml .Values.extraEnvs | indent 8 }}
         {{- end }}
         {{- if .Values.envFrom }}
         envFrom:
-{{ toYaml .Values.envFrom | indent 10 }}
+{{ toYaml .Values.envFrom | indent 8 }}
         {{- end }}
       {{- end }}
       {{- end }}


### PR DESCRIPTION
### Description
This fixes `yamllint` warnings due to inconsistent indentation in the rendered templates.
 
### Issues Resolved
Closes: #29 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
