### PR TITLE
Use consistent indentation in opensearch-dashboards templates

### DIFF
--- a/charts/opensearch-dashboards/templates/service.yaml
+++ b/charts/opensearch-dashboards/templates/service.yaml
@@ -21,13 +21,13 @@ spec:
 {{ toYaml . | indent 4 }}
 {{- end }}
   ports:
-    - port: {{ .Values.service.port }}
+  - port: {{ .Values.service.port }}
 {{- if .Values.service.nodePort }}
-      nodePort: {{ .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
 {{- end }}
-      protocol: TCP
-      name: {{ .Values.service.httpPortName | default "http" }}
-      targetPort: {{ .Values.service.port }}
+    protocol: TCP
+    name: {{ .Values.service.httpPortName | default "http" }}
+    targetPort: {{ .Values.service.port }}
   selector:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name | quote }}


### PR DESCRIPTION
### Description
This fixes `yamllint` warnings due to inconsistent indentation in the rendered templates.
 
### Issues Resolved
Closes: #28 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
