### PR TITLE
Use absolute path to opensearch-keystore binary

### DIFF
--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -224,18 +224,18 @@ spec:
           #!/usr/bin/env bash
           set -euo pipefail
 
-          opensearch-keystore create
+          {{ .Values.opensearchHome }}/bin/opensearch-keystore create
 
           for i in /tmp/keystoreSecrets/*/*; do
             key=$(basename $i)
             echo "Adding file $i to keystore key $key"
-            opensearch-keystore add-file "$key" "$i"
+            {{ .Values.opensearchHome }}/bin/opensearch-keystore add-file "$key" "$i"
           done
 
           # Add the bootstrap password since otherwise the opensearch entrypoint tries to do this on startup
           if [ ! -z ${PASSWORD+x} ]; then
             echo 'Adding env $PASSWORD to keystore as key bootstrap.password'
-            echo "$PASSWORD" | opensearch-keystore add -x bootstrap.password
+            echo "$PASSWORD" | {{ .Values.opensearchHome }}/bin/opensearch-keystore add -x bootstrap.password
           fi
 
           cp -a {{ .Values.opensearchHome }}/config/opensearch.keystore /tmp/keystore/


### PR DESCRIPTION
### Description
Since the `opensearch-keystore` binary is not in `$PATH`, use an absolute path.
 
### Issues Resolved
Closes: #26 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
