### PR TITLE
Use the new name of JAVA_OPTS variable

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -22,8 +22,8 @@ This chart is tested with the latest 1.0.0-rc1 version.
 * The chart deploys a StatefulSet and by default will do an automated rolling
   update of your cluster. It does this by waiting for the cluster health to become
   green after each instance is updated.
-* It is important to verify that the JVM heap size in `esJavaOpts` and to set
-  the CPU/Memory `resources` to something suitable for your cluster.
+* It is important to verify that the JVM heap size in `opensearchJavaOpts` and
+  to set the CPU/Memory `resources` to something suitable for your cluster.
 * To simplify chart and maintenance each set of node groups is deployed as a
   separate Helm release. Without doing this it isn't possible to resize persistent
   volumes in a StatefulSet. By setting it up this way it makes it possible to add

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -299,8 +299,8 @@ spec:
           value: "{{ .Values.clusterName }}"
         - name: network.host
           value: "{{ .Values.networkHost }}"
-        - name: ES_JAVA_OPTS
-          value: "{{ .Values.esJavaOpts }}"
+        - name: OPENSEARCH_JAVA_OPTS
+          value: "{{ .Values.opensearchJavaOpts }}"
         {{- range $role, $enabled := .Values.roles }}
         - name: node.{{ $role }}
           value: "{{ $enabled }}"

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -115,7 +115,7 @@ podAnnotations: {}
 # additionals labels
 labels: {}
 
-esJavaOpts: "-Xmx512M -Xms512M"
+opensearchJavaOpts: "-Xmx512M -Xms512M"
 
 resources:
   requests:


### PR DESCRIPTION
### Description
ES_JAVA_OPTS has been renamed in Opensearch to OPENSEARCH_JAVA_OPTS.

Note that this is a breaking change
 
### Issues Resolved
Closes: #38 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
