### PR TITLE
Add TheAlgo and DandyDeveloper as the new maintainers of the repo

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,5 +6,6 @@
 | Peter Zhu | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon |
 | Peter Nied | [peternied](https://github.com/peternied) | Amazon |
 | Sayali Gaikawad | [gaiksaya](https://github.com/gaiksaya) | Amazon |
+| Aaron Layfield | [DandyDeveloper](https://github.com/DandyDeveloper) | Community |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,6 +6,7 @@
 | Peter Zhu | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon |
 | Peter Nied | [peternied](https://github.com/peternied) | Amazon |
 | Sayali Gaikawad | [gaiksaya](https://github.com/gaiksaya) | Amazon |
+| Dhiraj Kumar Jain | [TheAlgo](https://github.com/TheAlgo) | Amazon |
 | Aaron Layfield | [DandyDeveloper](https://github.com/DandyDeveloper) | Community |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add TheAlgo and DandyDeveloper as the new maintainers of the repo
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
