### PR TITLE
Enable Helm chart release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
+## [Unreleased-Dashboards]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
+## [opensearch-1.0.2]
+
+### Added
+- Added this changelog in compliance with [Keep A Change Log](https://keepachangelog.com/en/1.0.0/).
+
+### Changed
+- Incremented the version to 1.0.2
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
+## [opensearch-dashboards-1.0.2]
+
+### Added
+- Added this changelog in compliance with [Keep A Change Log](https://keepachangelog.com/en/1.0.0/).
+
+### Changed
+- Incremented the version to 1.0.2
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.2...HEAD
+[opensearch-1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.1...opensearch-1.0.2
+
+[Unreleased-Dashboards]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.2...HEAD
+[opensearch-dashboards1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.1...opensearch-dashboards-1.0.2

--- a/README.md
+++ b/README.md
@@ -1,29 +1,38 @@
 <img src="https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg" height="64px"/>
 
 - [OpenSearch Project Helm-Charts](#helm-charts)
-- [Installation](#installation)
 - [Status](#status)
+- [Installation](#installation)
+- [Change Logs](#change-logs)
 - [Contributing](#contributing)
 - [Getting Help](#getting-help)
 - [Code of Conduct](#code-of-conduct)
 - [Security](#security)
 - [License](#license)
-- [Copyright](#copyright)
 
-## OpenSearch Project Helm-Charts
+## Helm-Charts
 
 A community repository for Helm Charts of OpenSearch Project.
-
-## Installation
-
-[OpenSearch Helm chart](https://opensearch.org/docs/opensearch/install/helm/)
-
-[OpenSearch Dashboards Helm chart](https://opensearch.org/docs/dashboards/install/helm/)
 
 ## Status
 
 ![Testing](https://github.com/opensearch-project/helm-charts/workflows/Lint%20and%20Test%20Charts/badge.svg)
 ![Release](https://github.com/opensearch-project/helm-charts/workflows/Release%20Charts/badge.svg)
+
+## Installation
+
+```shell
+helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+helm repo update
+```
+
+You can then run `helm search repo opensearch` to see the charts.
+
+## Change Logs
+
+Please review the [OpenSearch](charts/opensearch/CHANGELOG.md) and the
+[OpenSearch Dashboards](charts/opensearch/CHANGELOG.md) change logs for the latest 
+release details.
 
 ## Contributing
 
@@ -46,7 +55,3 @@ If you discover a potential security issue in this project we ask that you notif
 ## License
 
 This project is licensed under the [Apache v2.0 License](LICENSE.txt).
-
-## Copyright
-
-Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,23 +1,22 @@
 
 This Helm chart is a lightweight way to configure and run the official [OpenSearch Docker image](https://hub.docker.com/r/opensearchproject/opensearch).
 
-
 - [Installing](#installing)
 - [Usage notes](#usage-notes)
 - [Configuration](#configuration)
 - [Future](#Future)
 
-    
-
 ## Installing
 
-This chart is tested with the latest 1.0.0 version.
+```shell
+helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+helm repo update
+helm install my-release opensearch/opensearch-dashboards
+```
 
-* Clone this repo
-* Install it:
-    - with Helm 3: `helm install oss ./Helm/opensearch`
+You can then run `helm search repo opensearch` to see the charts.
 
-## Usage notes
+## Usage Notes
 
 * The chart deploys a StatefulSet and by default will do an automated rolling
   update of your cluster. It does this by waiting for the cluster health to become
@@ -37,7 +36,6 @@ This chart is tested with the latest 1.0.0 version.
 
 ## Configuration
 TODO : Write about all the parameters used
-
 
 ## Future
 * Create example for different types of configurations for different K8S providers.

--- a/charts/README.md
+++ b/charts/README.md
@@ -8,13 +8,9 @@ This Helm chart is a lightweight way to configure and run the official [OpenSear
 
 ## Installing
 
-```shell
-helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-helm repo update
-helm install my-release opensearch/opensearch-dashboards
-```
+[OpenSearch Helm chart](https://opensearch.org/docs/opensearch/install/helm/)
 
-You can then run `helm search repo opensearch` to see the charts.
+[OpenSearch Dashboards Helm chart](https://opensearch.org/docs/dashboards/install/helm/)
 
 ## Usage Notes
 

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
+## [1.0.2]
+
+### Added
+- Added this change log in compliance with [Keep A Change Log](https://keepachangelog.com/en/1.0.0/).
+
+### Changed
+- Incremented the version to `1.0.2`.
+
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+[Unreleasedd]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.2...HEAD
+[opensearch-dashboards-1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.1...opensearch-dashboards-1.0.2

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
+## [1.0.2]
+
+### Added
+- Added this change log in compliance with [Keep A Change Log](https://keepachangelog.com/en/1.0.0/).
+
+### Changed
+- Incremented the version to `1.0.2`.
+
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.2...HEAD
+[1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.1...opensearch-1.0.2

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opensearch
-description: A Helm chart for Kubernetes
+description: A Helm chart for OpenSearch
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/opensearch/README.md
+++ b/charts/opensearch/README.md
@@ -15,15 +15,13 @@ This Helm chart installs [OpenSearch](https://github.com/opensearch-project/Open
 
 ## Installing
 
-To install the chart with the release name `my-release`:
-- Switch to opensearch directly after cloning the repo
-  `❯ cd charts/opensearch`
-- Run `❯ helm package .`
-- Install using Helm 3:
-`❯ helm install my-release opensearch-1.0.0.tgz`
--  Install using Helm 2
-`❯ helm install --name my-release opensearch-1.0.0.tgz`
+```shell
+helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+helm repo update
+helm install my-release opensearch/opensearch
+```
 
+You can then run `helm search repo opensearch` to see the charts.
 
 The command deploys OpenSearch with its associated components (data statefulsets, masters, clients) on the Kubernetes cluster in the default configuration.
 

--- a/charts/opensearch/README.md
+++ b/charts/opensearch/README.md
@@ -15,13 +15,14 @@ This Helm chart installs [OpenSearch](https://github.com/opensearch-project/Open
 
 ## Installing
 
-```shell
-helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-helm repo update
-helm install my-release opensearch/opensearch
-```
-
-You can then run `helm search repo opensearch` to see the charts.
+To install the chart with the release name `my-release`:
+- Switch to opensearch directly after cloning the repo
+  `❯ cd charts/opensearch`
+- Run `❯ helm package .`
+- Install using Helm 3:
+`❯ helm install my-release opensearch-1.0.0.tgz`
+-  Install using Helm 2
+`❯ helm install --name my-release opensearch-1.0.0.tgz`
 
 The command deploys OpenSearch with its associated components (data statefulsets, masters, clients) on the Kubernetes cluster in the default configuration.
 


### PR DESCRIPTION
### Description
-  Added change logs for the opensearch and opensearch-dashboards Helm charts.
- Amended README files to reflect the intended installation and usage.
- Incremented the version numbers to 1.0.2 for both Helm charts in adherence to linting rules and Semver 2.

@peterzhuamazon @TheAlgo Before merging this PR, please create a branch named `gh-pages` as per [these](https://github.com/opensearch-project/helm-charts/issues/55#issuecomment-925421426) steps. 

Also, I took the liberty of creating a README.md for the `gh-pages` branch, which you can see [here](https://github.com/mprimeaux/helm-charts/tree/gh-pages#readme).  You can see what it looks like by navigating to https://mprimeaux.github.io/helm-charts/

Once the `gh-pages` branch is created, I'm happy to submit a PR for the README if you prefer.

### Issues Resolved
This PR resolves issue #55. 
 
### Check List
- [:heavy_check_mark:] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
