### PR TITLE
fix: yaml indentation in statefulset for `extraEnvs`, `envFrom` and `extraVolumeMounts`

### DIFF
--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -251,8 +251,8 @@ spec:
           fi
 
           cp -a {{ .Values.opensearchHome }}/config/opensearch.keystore /tmp/keystore/
-        env: {{ toYaml .Values.extraEnvs | nindent 10 }}
-        envFrom: {{ toYaml .Values.envFrom | nindent 10 }}
+        env: {{ toYaml .Values.extraEnvs | nindent 8 }}
+        envFrom: {{ toYaml .Values.envFrom | nindent 8 }}
         resources: {{ toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
         - name: keystore
@@ -322,7 +322,7 @@ spec:
 {{- end }}
 {{- if .Values.envFrom }}
         envFrom:
-{{ toYaml .Values.envFrom | indent 10 }}
+{{ toYaml .Values.envFrom | indent 8 }}
 {{- end }}
         volumeMounts:
         {{- if .Values.persistence.enabled }}
@@ -387,9 +387,9 @@ spec:
         # to continue with backwards compatibility this is being kept
         # whilst also allowing for yaml to be specified too.
         {{- if eq "string" (printf "%T" .Values.extraVolumeMounts) }}
-{{ tpl .Values.extraVolumeMounts . | indent 10 }}
+{{ tpl .Values.extraVolumeMounts . | indent 8 }}
         {{- else }}
-{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
         {{- end }}
         {{- end }}
       {{- if .Values.masterTerminationFix }}

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -318,7 +318,7 @@ spec:
           value: "{{ $enabled }}"
         {{- end }}
 {{- if .Values.extraEnvs }}
-{{ toYaml .Values.extraEnvs | indent 10 }}
+{{ toYaml .Values.extraEnvs | indent 8 }}
 {{- end }}
 {{- if .Values.envFrom }}
         envFrom:


### PR DESCRIPTION
Signed-off-by: Stein Arne Storslett <sastorsl@users.noreply.github.com>

### Description
Fix toYaml error when adding `extraEnvs`, `envFrom` and `extraVolumeMounts` to `values.yaml`.

Passes `helm lint -f values.yaml ./` and install after adding `extraEnvs` after change.

### Issues Resolved
This PR resolves issue #52, #64 and #65
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
