### PR TITLE
indentation corrected in extra volume mounts, changed from nindent 10…

### DIFF
--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -387,9 +387,9 @@ spec:
         # to continue with backwards compatibility this is being kept
         # whilst also allowing for yaml to be specified too.
         {{- if eq "string" (printf "%T" .Values.extraVolumeMounts) }}
-{{ tpl .Values.extraVolumeMounts . | indent 10 }}
+{{ tpl .Values.extraVolumeMounts . | indent 8 }}
         {{- else }}
-{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
         {{- end }}
         {{- end }}
       {{- if .Values.masterTerminationFix }}


### PR DESCRIPTION
… to nindent 8

### Description
[Consumer will be able to use extravolume mounts to mount a secret , for eg; tls certs]
 
### Issues Resolved
[https://github.com/opensearch-project/helm-charts/issues/72]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
