### PR TITLE
Incorrect indentation for `extraVolumeMounts`, `extraEnvs`, `envFrom` in `statefulset.yaml`.

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
+## [1.0.4]
+### Added
+### Changed
+- Amended installation instructions.
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
 ## [1.0.2]
 
 ### Added
@@ -27,5 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.2...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.4...HEAD
+[1.0.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.2...opensearch-1.0.4
 [1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.1...opensearch-dashboards-1.0.2

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -27,5 +27,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleasedd]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.2...HEAD
-[opensearch-dashboards-1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.1...opensearch-dashboards-1.0.2
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.2...HEAD
+[1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.1...opensearch-dashboards-1.0.2

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
+## [1.0.3]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- [ISSUE-65](https://github.com/opensearch-project/helm-charts/issues/65): Incorrect indentation for `extraVolumeMounts`, `extraEnvs`, `envFrom` in `statefulset.yaml`.
+### Security
+
+---
 ## [1.0.2]
 
 ### Added
@@ -27,5 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.2...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.3...HEAD
+[1.0.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.2...opensearch-1.0.3
 [1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.1...opensearch-1.0.2

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
-## [1.0.3]
+## [1.0.4]
 ### Added
 ### Changed
+- Amended installation instructions.
 ### Deprecated
 ### Removed
 ### Fixed
@@ -37,6 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.3...HEAD
-[1.0.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.2...opensearch-1.0.3
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.4...HEAD
+[1.0.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.2...opensearch-1.0.4
 [1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.1...opensearch-1.0.2

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -251,8 +251,8 @@ spec:
           fi
 
           cp -a {{ .Values.opensearchHome }}/config/opensearch.keystore /tmp/keystore/
-        env: {{ toYaml .Values.extraEnvs | nindent 10 }}
-        envFrom: {{ toYaml .Values.envFrom | nindent 10 }}
+        env: {{ toYaml .Values.extraEnvs | nindent 8 }}
+        envFrom: {{ toYaml .Values.envFrom | nindent 8 }}
         resources: {{ toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
         - name: keystore
@@ -318,11 +318,11 @@ spec:
           value: "{{ $enabled }}"
         {{- end }}
 {{- if .Values.extraEnvs }}
-{{ toYaml .Values.extraEnvs | indent 10 }}
+{{ toYaml .Values.extraEnvs | indent 8 }}
 {{- end }}
 {{- if .Values.envFrom }}
         envFrom:
-{{ toYaml .Values.envFrom | indent 10 }}
+{{ toYaml .Values.envFrom | indent 8 }}
 {{- end }}
         volumeMounts:
         {{- if .Values.persistence.enabled }}
@@ -387,9 +387,9 @@ spec:
         # to continue with backwards compatibility this is being kept
         # whilst also allowing for yaml to be specified too.
         {{- if eq "string" (printf "%T" .Values.extraVolumeMounts) }}
-{{ tpl .Values.extraVolumeMounts . | indent 10 }}
+{{ tpl .Values.extraVolumeMounts . | indent 8 }}
         {{- else }}
-{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
         {{- end }}
         {{- end }}
       {{- if .Values.masterTerminationFix }}


### PR DESCRIPTION
Signed-off-by: Michael Primeaux <michael.primeaux@mac.com>

### Description
**Describe the bug**
The Stateful Set template specifies an incorrect indentation of 10 for `extraEnvs`, `extraVolumeMounts`, and `envFrom`. The correct value is 8. 

<details>
  <summary>Error</summary>
  <p>

```shell
Error: INSTALLATION FAILED: YAML parse error on logging/charts/opensearch/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 122: did not find expected key
make: *** [install] Error 1
```
</p>
</details>

**To Reproduce**
Steps to reproduce the behavior:

Specify values for the `extraEnvs` stanza in the `values.yaml` file for the OpenSearch chart. For example,

<details>
  <summary>extraEnvs Example</summary>
  <p>

```yaml
extraEnvs:
  - name: NODE_TLS_REJECT_UNAUTHORIZED
    value: "0"
```
</p>
</details>

**Expected behavior**
The expected behavior is for the chart to install.

**Chart Name**
Specify the Chart which is affected? OpenSearch

**Screenshots**
None

**Host/Environment (please complete the following information):**
 - Helm Version: v3.7.0
 - Kubernetes Version: 1.21 (Amazon EKS)

**Additional context**
None.

### Issues Resolved
This will resolve issues #64 and #65 
 
### Check List
- [✔️] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
