### PR TITLE
Change appVersion of OpenSearch and Dashboards chart

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
+---
+## [1.0.6]
+### Added
+### Changed
+- Change `appVersion` to `1.1.0`. OpenSearch Dashboards chart will have by default underlying image of `opensearchproject/opensearch-dashboards:1.1.0`
+### Deprecated
+### Removed
+### Fixed
+### Security
 
 ---
 ## [1.0.5]

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 
 maintainers:
   - name: DandyDeveloper

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -12,7 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
+---
+## [1.2.4]
+### Added
+### Changed
+- Change `appVersion` to `1.1.0`. OpenSearch Dashboards chart will have by default underlying image of `opensearchproject/opensearch:1.1.0`
+### Deprecated
+### Removed
+### Fixed
+### Security
 ---
 ## [1.2.3]
 ### Added

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.3
+version: 1.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 
 maintainers:
   - name: DandyDeveloper


### PR DESCRIPTION
Signed-off-by: TheAlgo <dhirajjain0@gmail.com>

### Description
This PR changes the `appVersion` of `OpenSearch` and `OpenSearch Dashboards`. After this being merged both the charts will be using `1.1` images as the underlying image
 
### Issues Resolved
#97 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
