### PR TITLE
fix: Handle log4j2 not being yaml (#110)

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
+---
+## [1.0.6]
+### Added
+### Changed
+- Change `appVersion` to `1.1.0`. OpenSearch Dashboards chart will have by default underlying image of `opensearchproject/opensearch-dashboards:1.1.0`
+### Deprecated
+### Removed
+### Fixed
+### Security
 
 ---
 ## [1.0.5]

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 
 maintainers:
   - name: DandyDeveloper

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -12,7 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
+---
+## [1.2.4]
+### Added
+### Changed
+- Change `appVersion` to `1.1.0`. OpenSearch Dashboards chart will have by default underlying image of `opensearchproject/opensearch:1.1.0`
+### Deprecated
+### Removed
+### Fixed
+### Security
 ---
 ## [1.2.3]
 ### Added

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.3
+version: 1.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.4
+version: 1.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -21,7 +21,7 @@ version: 1.2.5
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 
 maintainers:
   - name: DandyDeveloper

--- a/charts/opensearch/templates/configmap.yaml
+++ b/charts/opensearch/templates/configmap.yaml
@@ -7,7 +7,12 @@ metadata:
     {{- include "opensearch.labels" . | nindent 4 }}
 data:
 {{- range $configName, $configYaml := .Values.config }}
+  {{- if eq $configName "log4j2.properties" }}
+  {{ $configName }}: |
+    {{- $configYaml | nindent 4 }}
+  {{- else }}
   {{ $configName }}: |
     {{- toYaml $configYaml | nindent 4 }}
+  {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Bump chart (#110)

Signed-off-by: Stein Arne Storslett <sastorsl@users.noreply.github.com>

### Description
Render `log4j2.properties` properly when added to `values.yaml` / `config`.
The current version does a `toYaml`, but log4j2 is `key = value` based and not yaml so without this PR log4j2 will not be rendered properly (see issue for details).

Maintainers may adjust the Chart version as needs be, ie. to align with other PR's but please contact me for any other changes.
 
### Issues Resolved
#110 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).