### PR TITLE
[Dashboards] Add extraVolumes and extraVolumeMounts

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.0.7]
+### Added
+- Add `extraVolumes` and `extraVolumeMounts`.
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
 ## [1.0.6]
 ### Added
 ### Changed
@@ -56,7 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.5...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.6...HEAD
+[1.0.6]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.5...opensearch-1.0.6
 [1.0.5]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.4...opensearch-1.0.5
 [1.0.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.2...opensearch-1.0.4
 [1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.1...opensearch-dashboards-1.0.2

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/deployment.yaml
+++ b/charts/opensearch-dashboards/templates/deployment.yaml
@@ -48,6 +48,16 @@ spec:
           configMap:
             name: {{ template "opensearch-dashboards.fullname" . }}-config
         {{- end }}
+        {{- if .Values.extraVolumes }}
+        # Currently some extra blocks accept strings
+        # to continue with backwards compatibility this is being kept
+        # whilst also allowing for yaml to be specified too.
+        {{- if eq "string" (printf "%T" .Values.extraVolumes) }}
+{{ tpl .Values.extraVolumes . | indent 8 }}
+        {{- else }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+        {{- end }}
+        {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -145,6 +155,16 @@ spec:
           - name: config
             mountPath: /usr/share/opensearch-dashboards/config/{{ $path }}
             subPath: {{ $path }}
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          # Currently some extra blocks accept strings
+          # to continue with backwards compatibility this is being kept
+          # whilst also allowing for yaml to be specified too.
+          {{- if eq "string" (printf "%T" .Values.extraVolumeMounts) }}
+{{ tpl .Values.extraVolumeMounts . | indent 10 }}
+         {{- else }}
+{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+          {{- end }}
           {{- end }}
       {{- if .Values.extraContainers }}
       # Currently some extra blocks accept strings

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -44,6 +44,15 @@ extraEnvs: []
 
 envFrom: []
 
+extraVolumes: []
+  # - name: extras
+  #   emptyDir: {}
+
+extraVolumeMounts: []
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+
 extraInitContainers: ""
 
 extraContainers: ""


### PR DESCRIPTION
### Description
User can define extra volumes for opensearch-dashboards

### Test Results:

* Deploy using the following chart values :
```
extraVolumes:
  - name: my-ca-trust
    hostPath:
      path: "/etc/ssl/certs"

extraVolumeMounts:
  - name: my-ca-trust
    mountPath: /usr/share/opensearch-dashboards/config/certs
    readOnly: true
```
* Check the volumes on the opensearch-dashboards pod
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
