### PR TITLE
Fix node.roles environment variable

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.4.2]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- `node.roles` environment variable
+### Security
+---
 ## [1.4.1]
 ### Added
 ### Changed

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -315,10 +315,8 @@ spec:
           value: "{{ .Values.networkHost }}"
         - name: OPENSEARCH_JAVA_OPTS
           value: "{{ .Values.opensearchJavaOpts }}"
-        {{- range $role, $enabled := .Values.roles }}
-        - name: node.{{ $role }}
-          value: "{{ $enabled }}"
-        {{- end }}
+        - name: node.roles
+          value: "{{ template "opensearch.roles" . }}"
 {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 8 }}
 {{- end }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -7,7 +7,7 @@ nodeGroup: "master"
 masterService: "opensearch-cluster-master"
 
 # OpenSearch roles that will be applied to this nodeGroup
-# These will be set as environment variables. E.g. node.master=true
+# These will be set as environment variable "node.roles". E.g. node.roles=master,ingest,data,remote_cluster_client
 roles:
   - master
   - ingest


### PR DESCRIPTION
Signed-off-by: Tomas Odehnal <tomas.odehnal@runecast.com>

### Description
[There was a change](https://github.com/opensearch-project/helm-charts/commit/d45f215b72c84f331e0d6344b9c82749c012a41c) to fix deprecated node roles setting via environment variables. This PR fixes the missing environment variable `node.roles` that replaces the old node roles variables format.
 
### Issues Resolved
https://github.com/opensearch-project/helm-charts/issues/132
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
