### PR TITLE
Added default value to securityConfigSecret

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.4.4]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Added a default value to securityConfigSecret to fix issue [#146](https://github.com/opensearch-project/helm-charts/issues/146).
+### Security
+---
 ## [1.4.3]
 ### Added
 ### Changed

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.3
+version: 1.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -306,7 +306,7 @@ securityConfig:
     # * If you define securityConfigSecret, the chart will assume this secret is
     #   created externally and mount it.
     # * It is an error to define both data and securityConfigSecret.
-    securityConfigSecret: ""
+    securityConfigSecret: "security-configs-secret"
     data: {}
       # config.yml: |-
       # internal_users.yml: |-


### PR DESCRIPTION
Signed-off-by: David Calvert <davidcalvertfr@gmail.com>

### Description
This PR is a copy from the [#750 ](https://github.com/opendistro-for-elasticsearch/opendistro-build/pull/750) I did for Opendistro. 
Added a default value to securityConfigSecret to make this feature work straight away.\
I didn't find any instructions on bumping the chart version so I left it unchanged. Let me know if you want me to bump it in this PR.
 
### Issues Resolved
[#702 ](https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/702) (This issue is from Opendistro)
#146 in OpenSearch
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
