### PR TITLE
fix: deprecated api migration versions

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.5.3]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Fixed behavior for `PodSecurityPolicy` in the opensearch chart [Issue #157](https://github.com/opensearch-project/helm-charts/issues/157)
+### Security
+---
 ## [1.5.2]
 ### Added
 ### Changed

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.2
+version: 1.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/podsecuritypolicy.yaml
+++ b/charts/opensearch/templates/podsecuritypolicy.yaml
@@ -1,10 +1,7 @@
+{{- if semverCompare "<1.25-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- if .Values.podSecurityPolicy.create -}}
 {{- $fullName := include "opensearch.uname" . -}}
-{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: policy/v1
-{{- else -}}
 apiVersion: policy/v1beta1
-{{- end }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ default $fullName .Values.podSecurityPolicy.name | quote }}
@@ -15,5 +12,6 @@ spec:
 {{- if .Values.sysctl.enabled }}
   allowedUnsafeSysctls:
   - vm.max_map_count
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Michael Rödel <hello@mroedel.de>

### Description
Change the semverCompare for PodSecurityPolicy according to https://kubernetes.io/docs/reference/using-api/deprecation-guide/
 
### Issues Resolved
#157 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
