### PR TITLE
Added flag to control the network policy creation

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
 ---
 ## [1.5.4]
 ### Added

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,21 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 ---
 ## [1.5.5]
-
 ### Added
-
 - Added `create` flag into the `networkPolicy` resource to enable the creation of a network policy as request, for the cases where an user can't create network policies but want to use this chart.
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
 ## [1.5.4]
 ### Added
@@ -38,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.5.3]
 ### Added

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.5.4]
+
+### Added
+
+- Added `create` flag into the `networkPolicy` resource to enable the creation of a network policy as request, for the cases where an user can't create network policies but want to use this chart.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+
+---
 ## [1.5.3]
 ### Added
 ### Changed
@@ -235,7 +253,10 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.5.1...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.5.4...HEAD
+[1.5.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.5.3...opensearch-1.5.4
+[1.5.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.5.2...opensearch-1.5.3
+[1.5.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.5.1...opensearch-1.5.2
 [1.5.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.5.0...opensearch-1.5.1
 [1.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.4.3...opensearch-1.5.0
 [1.4.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.4.2...opensearch-1.4.3
@@ -256,4 +277,3 @@ config:
 [1.0.5]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.4...opensearch-1.0.5
 [1.0.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.2...opensearch-1.0.4
 [1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.1...opensearch-1.0.2
-

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.3
+version: 1.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.4
+version: 1.5.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/README.md
+++ b/charts/opensearch/README.md
@@ -2,10 +2,10 @@
 
 This Helm chart installs [OpenSearch](https://github.com/opensearch-project/OpenSearch) with configurable TLS, RBAC and much more configurations. This chart caters a number of different use cases and setups.
 
-  - [Requirements](#requirements)
-  - [Installing](#installing)
-  - [Uninstalling](#uninstalling)
-  - [Configuration](#configuration)
+- [Requirements](#requirements)
+- [Installing](#installing)
+- [Uninstalling](#uninstalling)
+- [Configuration](#configuration)
 
 ## Requirements
 
@@ -66,7 +66,7 @@ helm uninstall my-release
 | `minimumMasterNodes`               | The value for `discovery.zen.minimum_master_nodes`                                                                                 | `2`                                             |
 | `nameOverride`                     | Overrides the `clusterName` when used in the naming of resources                                                                                                                                                                                          | `""`                                            |
 | `networkHost`                      | Value for the `network.host OpenSearch setting`                                                                                                                                                                                                      | `0.0.0.0`                                       |
-| `networkPolicy.create`                      | Enable network policy creation for OpenSearch | `false`
+| `networkPolicy.create`             | Enable network policy creation for OpenSearch                              | `false`
 | `nodeAffinity`                     | Value for the [node affinity settings][]                                                                                                                                                                                                                  | `{}`                                            |
 | `nodeGroup`                        | This is the name that will be used for each group of nodes in the cluster. The name will be `clusterName-nodeGroup-X` , `nameOverride-nodeGroup-X` if a `nameOverride` is specified, and `fullnameOverride-X` if a `fullnameOverride` is specified        | `master`                                        |
 | `nodeSelector`                     | Configurable [nodeSelector][] so that you can target specific nodes for your OpenSearch cluster                                                                                                                                                        | `{}`                                            |

--- a/charts/opensearch/README.md
+++ b/charts/opensearch/README.md
@@ -1,11 +1,10 @@
 # OpenSearch Helm Chart
 
 This Helm chart installs [OpenSearch](https://github.com/opensearch-project/OpenSearch) with configurable TLS, RBAC and much more configurations. This chart caters a number of different use cases and setups.
-
-- [Requirements](#requirements)
-- [Installing](#installing)
-- [Uninstalling](#uninstalling)
-- [Configuration](#configuration)
+  - [Requirements](#requirements)
+  - [Installing](#installing)
+  - [Uninstalling](#uninstalling)
+  - [Configuration](#configuration)
 
 ## Requirements
 
@@ -66,6 +65,7 @@ helm uninstall my-release
 | `minimumMasterNodes`               | The value for `discovery.zen.minimum_master_nodes`                                                                                 | `2`                                             |
 | `nameOverride`                     | Overrides the `clusterName` when used in the naming of resources                                                                                                                                                                                          | `""`                                            |
 | `networkHost`                      | Value for the `network.host OpenSearch setting`                                                                                                                                                                                                      | `0.0.0.0`                                       |
+| `networkPolicy.create`                      | Enable network policy creation for OpenSearch
 | `nodeAffinity`                     | Value for the [node affinity settings][]                                                                                                                                                                                                                  | `{}`                                            |
 | `nodeGroup`                        | This is the name that will be used for each group of nodes in the cluster. The name will be `clusterName-nodeGroup-X` , `nameOverride-nodeGroup-X` if a `nameOverride` is specified, and `fullnameOverride-X` if a `fullnameOverride` is specified        | `master`                                        |
 | `nodeSelector`                     | Configurable [nodeSelector][] so that you can target specific nodes for your OpenSearch cluster                                                                                                                                                        | `{}`                                            |

--- a/charts/opensearch/README.md
+++ b/charts/opensearch/README.md
@@ -1,6 +1,7 @@
 # OpenSearch Helm Chart
 
 This Helm chart installs [OpenSearch](https://github.com/opensearch-project/OpenSearch) with configurable TLS, RBAC and much more configurations. This chart caters a number of different use cases and setups.
+
   - [Requirements](#requirements)
   - [Installing](#installing)
   - [Uninstalling](#uninstalling)
@@ -65,7 +66,7 @@ helm uninstall my-release
 | `minimumMasterNodes`               | The value for `discovery.zen.minimum_master_nodes`                                                                                 | `2`                                             |
 | `nameOverride`                     | Overrides the `clusterName` when used in the naming of resources                                                                                                                                                                                          | `""`                                            |
 | `networkHost`                      | Value for the `network.host OpenSearch setting`                                                                                                                                                                                                      | `0.0.0.0`                                       |
-| `networkPolicy.create`                      | Enable network policy creation for OpenSearch
+| `networkPolicy.create`                      | Enable network policy creation for OpenSearch | `false`
 | `nodeAffinity`                     | Value for the [node affinity settings][]                                                                                                                                                                                                                  | `{}`                                            |
 | `nodeGroup`                        | This is the name that will be used for each group of nodes in the cluster. The name will be `clusterName-nodeGroup-X` , `nameOverride-nodeGroup-X` if a `nameOverride` is specified, and `fullnameOverride-X` if a `fullnameOverride` is specified        | `master`                                        |
 | `nodeSelector`                     | Configurable [nodeSelector][] so that you can target specific nodes for your OpenSearch cluster                                                                                                                                                        | `{}`                                            |

--- a/charts/opensearch/templates/networkpolicy.yaml
+++ b/charts/opensearch/templates/networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.networkPolicy.create -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -13,3 +14,4 @@ spec:
   podSelector:
     matchLabels:
       {{ template "opensearch.uname" . }}-transport-client: "true"
+{{- end }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -383,6 +383,7 @@ lifecycle: {}
 keystore: []
 
 networkPolicy:
+  create: false
   ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
   ## In order for a Pod to access OpenSearch, it needs to have the following label:
   ## {{ template "uname" . }}-client: "true"


### PR DESCRIPTION
### Description
This change was relative to a new flag that will validate the need to create a network policy. I had an use case where the user accounts can't create network policies.
  
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).