### PR TITLE
prefer .Chart.AppVersion by default

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
+## [1.1.2]
+### Added
+### Changed
+- Removed default imageTag from values.yaml to use Chart appVersion image tag by default.
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
 ## [1.1.1]
 ### Added
 ### Changed
@@ -97,7 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.1.1...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.1.2...HEAD
+[1.1.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.1.1...opensearch-1.1.2
 [1.1.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.1.0...opensearch-1.1.1
 [1.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.8...opensearch-1.1.0
 [1.0.8]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.7...opensearch-1.0.8

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -9,7 +9,8 @@ opensearchHosts: "https://opensearch-cluster-master:9200"
 replicaCount: 1
 
 image: "opensearchproject/opensearch-dashboards"
-imageTag: "1.0.0"
+# override image tag, which is .Chart.AppVersion by default
+imageTag: ""
 imagePullPolicy: "IfNotPresent"
 
 imagePullSecrets: []


### PR DESCRIPTION
### Description
Do not specify `imageTag` in the default `values.yaml` and use .Chart.AppVersion by default.
This way the behavior will match `opensearch` chart.
 
### Issues Resolved
#177
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
