### PR TITLE
Fix opensearch container imagePullPolicy typo

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.7.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Fixed `image.pullPolicy` Helm value not setting the `imagePullPolicy` for the "opensearch" container 
+### Security
+---
 ## [1.7.0]
 ### Added
 ### Changed
@@ -304,7 +313,8 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.7.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.7.1...HEAD
+[1.7.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.7.0...opensearch-1.7.1
 [1.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.6.0...opensearch-1.7.0
 [1.6.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.5.8...opensearch-1.6.0
 [1.5.8]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.5.7...opensearch-1.5.8

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 1.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -290,7 +290,7 @@ spec:
           bash opensearch-docker-entrypoint.sh
       {{- end }}
         image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        imagePullPolicy: "{{ .Values.image.PullPolicy }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         ports:
         - name: http
           containerPort: {{ .Values.httpPort }}


### PR DESCRIPTION
### Description
The value in the Helm values.yaml is `image.pullPolicy` but the value in the template is `image.PullPolicy` so the generated yaml for the opensearch statefulset will always have `imagePullPolicy: ""` no matter the value of `image.pullPolicy` that the user specifies.  The other instances of `imagePullPolicy` are already correctly set in the templates.

### Issues Resolved
Closes https://github.com/opensearch-project/helm-charts/issues/206
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
