### PR TITLE
Update statefulset.yaml

### DIFF
--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 1.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -392,6 +392,12 @@ spec:
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
         {{- end }}
         {{- end }}
+        startupProbe:
+          tcpSocket:
+            port: 9200
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
       {{- if .Values.masterTerminationFix }}
       {{- if eq .Values.roles.master "true" }}
       # This sidecar will prevent slow master re-election


### PR DESCRIPTION
Adding a startupProbe to fix opensearch-project#198 
When helm upgrades master pods, it kills all old master pods in a few seconds, leaving no time for new master pods to start up and join the cluster, eventually killing the whole cluster. A 30-second startupProbe solve this problem

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
