### PR TITLE
fix for rendering configMap correctly

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.2.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Fixed rendering of `opensearch-dashboard.yml` in `configmap.yaml`.
+### Security
+
+
+---
 ## [1.2.0]
 ### Added
 ### Changed
@@ -21,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
+
 ---
 ## [1.1.2]
 ### Added

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.0"
+appVersion: "1.2.1"
 
 maintainers:
   - name: DandyDeveloper

--- a/charts/opensearch-dashboards/templates/configmap.yaml
+++ b/charts/opensearch-dashboards/templates/configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   labels: {{ include "opensearch-dashboards.labels" . | nindent 4 }}
 data:
 {{- range $configName, $configYaml := .Values.config }}
-  {{ $configName }}: |
-    {{- toYaml $configYaml | nindent 4 }}
+  {{ $configName }}: {{- toYaml $configYaml | nindent 4 }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Christian Lischnig <christian.lischnig@dccs.at>

### Description
With this change the opensearch_dashboards.yml is rendered correctly.
 
### Issues Resolved
[[BUG][opensearch-dashboards] configMap does not renderd correctly](https://github.com/opensearch-project/helm-charts/issues/156)
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
