### PR TITLE
Remove Peter Nied as maintainer of Helm repo

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,6 @@
 | --------------- | --------- | ----------- |
 | Barani Bikshandi | [bbarani](https://github.com/bbarani) | Amazon |
 | Peter Zhu | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon |
-| Peter Nied | [peternied](https://github.com/peternied) | Amazon |
 | Sayali Gaikawad | [gaiksaya](https://github.com/gaiksaya) | Amazon |
 | Dhiraj Kumar Jain | [TheAlgo](https://github.com/TheAlgo) | Amazon |
 | Aaron Layfield | [DandyDeveloper](https://github.com/DandyDeveloper) | Community |


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove Peter Nied as maintainer of Helm repo.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
