### PR TITLE
Bugfix for opensearch statefulset

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -359,7 +359,8 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.1...HEAD
+[1.8.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.0...opensearch-1.8.1
 [1.8.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.7.4...opensearch-1.8.0
 [1.7.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.7.3...opensearch-1.7.4
 [1.7.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.7.2...opensearch-1.7.3

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
+## [1.8.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Fixed small syntax bug in `StatefulSet` when `masterTerminationFix` is set.
+### Security
+---
 ## [1.8.0]
 ### Added
 ### Changed

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.0
+version: 1.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -407,7 +407,7 @@ spec:
         {{- end }}
         {{- end }}
       {{- if .Values.masterTerminationFix }}
-      {{- if eq .Values.roles.master "true" }}
+      {{- if has "master" .Values.roles }}
       # This sidecar will prevent slow master re-election
       - name: opensearch-master-graceful-termination-handler
         image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
### Description
Small syntax bugfix for the OpenSearch chart `StatefulSet`.

To minimally reproduce:

values.yaml
```
masterTerminationFix: true
roles:
  - master
```
 
` helm template --debug --dry-run . -f values.yaml`
```
Error: template: opensearch/templates/statefulset.yaml:410:23: executing "opensearch/templates/statefulset.yaml" at <.Values.roles.master>: can't evaluate field master in type interface {}
helm.go:84: [debug] template: opensearch/templates/statefulset.yaml:410:23: executing "opensearch/templates/statefulset.yaml" at <.Values.roles.master>: can't evaluate field master in type interface {}
```

After this fix, the `StatefulSet` can properly be templated and includes the master termination helper sidecar.

### Issues Resolved
https://github.com/opensearch-project/helm-charts/issues/226
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
