### PR TITLE
opensearch: add selector to volumeClaimTemplates

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.10.1]
+### Added
+- Add support for selector in `volumeClaimTemplates`
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.10.0]
 ### Added
 ### Changed
@@ -394,7 +403,8 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.10.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.10.1...HEAD
+[1.10.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.10.0...opensearch-1.10.1
 [1.10.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.9.0...opensearch-1.10.0
 [1.9.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.3...opensearch-1.9.0
 [1.8.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.2...opensearch-1.8.3

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.0
+version: 1.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.1
+version: 1.10.1-fix-indent
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.1-fix-indent
+version: 1.10.1-fix-indent-2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -43,6 +43,9 @@ spec:
       storageClassName: "{{ .Values.persistence.storageClass }}"
     {{- end }}
     {{- end }}
+    {{- if .Values.persistence.selector }}
+    selector: "{{ .Values.persistence.selector }}"
+    {{- end }}
   {{- end }}
   template:
     metadata:

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -44,8 +44,8 @@ spec:
     {{- end }}
     {{- end }}
     {{- if .Values.persistence.matchLabels }}
-    selector:
-      matchLabels:
+      selector:
+        matchLabels:
     {{- toYaml .Values.persistence.matchLabels | indent 12 }}
     {{- end }}
   {{- end }}

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -43,8 +43,10 @@ spec:
       storageClassName: "{{ .Values.persistence.storageClass }}"
     {{- end }}
     {{- end }}
-    {{- if .Values.persistence.selector }}
-    selector: "{{ .Values.persistence.selector }}"
+    {{- if .Values.persistence.matchLabels }}
+    selector:
+      matchLabels:
+    {{- toYaml .Values.persistence.matchLabels | indent 12 }}
     {{- end }}
   {{- end }}
   template:

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -46,7 +46,7 @@ spec:
     {{- if .Values.persistence.matchLabels }}
       selector:
         matchLabels:
-    {{- toYaml .Values.persistence.matchLabels | indent 12 }}
+    {{- toYaml .Values.persistence.matchLabels | nindent 10 }}
     {{- end }}
   {{- end }}
   template:

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -202,6 +202,8 @@ persistence:
   #   GKE, AWS & OpenStack)
   #
   # storageClass: "-"
+  # Selector is used to pin the created pvc to a specific statically provisioned pv
+  # selector:
   accessModes:
     - ReadWriteOnce
   size: 8Gi

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -202,8 +202,8 @@ persistence:
   #   GKE, AWS & OpenStack)
   #
   # storageClass: "-"
-  # Selector is used to pin the created pvc to a specific statically provisioned pv
-  # selector:
+  # matchLabels is used to pin the created pvc to a specific statically provisioned pv
+  # matchLabels:
   accessModes:
     - ReadWriteOnce
   size: 8Gi


### PR DESCRIPTION
Signed-off-by: Pierre Peloille <pierre.p@padoa-group.com>

### Description
This pr adds the ability to specify a selector in the `volumeClaimTemplate` for the opensearch chart.


### Issues Resolved
Fixes #239 

### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
