### PR TITLE
Update opensearch version to 1.3.1 in helm charts

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,6 +5,7 @@
 | Barani Bikshandi | [bbarani](https://github.com/bbarani) | Amazon |
 | Peter Zhu | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon |
 | Sayali Gaikawad | [gaiksaya](https://github.com/gaiksaya) | Amazon |
+| Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon |
 | Dhiraj Kumar Jain | [TheAlgo](https://github.com/TheAlgo) | Amazon |
 | Aaron Layfield | [DandyDeveloper](https://github.com/DandyDeveloper) | Community |
 

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.3.3]
+### Added
+### Changed
+- Updated maintainer list
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.3.2]
 ### Added
 - Added pod autoscaling capability.
@@ -167,7 +176,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.3.2...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.3.3...HEAD
+[1.3.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.3.2...opensearch-1.3.3
 [1.3.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.3.1...opensearch-1.3.2
 [1.3.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.3.0...opensearch-1.3.1
 [1.3.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.2.2...opensearch-1.3.0

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.2
+version: 1.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -28,4 +28,5 @@ maintainers:
   - name: bbarani
   - name: gaiksaya
   - name: peterzhuamazon
+  - name: prudhvigodithi
   - name: TheAlgo

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.10.0]
+### Added
+### Changed
+- Update app version to OpenSearch 1.3.1
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.9.0]
 ### Added
 ### Changed
@@ -385,7 +394,8 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.9.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.10.0...HEAD
+[1.10.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.9.0...opensearch-1.10.0
 [1.9.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.3...opensearch-1.9.0
 [1.8.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.2...opensearch-1.8.3
 [1.8.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.1...opensearch-1.8.2

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,17 +15,18 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.0
+version: 1.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.0"
+appVersion: "1.3.1"
 
 maintainers:
   - name: DandyDeveloper
   - name: bbarani
   - name: gaiksaya
   - name: peterzhuamazon
+  - name: prudhvigodithi
   - name: TheAlgo


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Update opensearch version to 1.3.1 in helm charts
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
