### PR TITLE
Add 2.x appVersion as optional version for helm charts

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.5.1]
+### Added
+- Add optional appVersion for 2.x OpenSearch-Dashboards release
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.4.1]
 ### Added
 - Update `values.yaml` example to use the correct format for configs
@@ -194,7 +203,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.4.1...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.5.1...HEAD
+[1.5.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.4.1...opensearch-1.5.1
 [1.4.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.4.0...opensearch-1.4.1
 [1.4.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.3.3...opensearch-1.4.0
 [1.3.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.3.2...opensearch-1.3.3

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -22,10 +22,10 @@ version: 1.5.1
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-# 1.x Version Latest
+# 1.x Latest Version
 appVersion: "1.3.1"
 
-# 2.x Version Latest
+# 2.x Latest Version
 # appVersion: "2.0.0-rc1"
 
 maintainers:

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,13 +15,18 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+
+# 1.x Version Latest
 appVersion: "1.3.1"
+
+# 2.x Version Latest
+#appVersion: "2.0.0-rc1"
 
 maintainers:
   - name: DandyDeveloper

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -26,7 +26,7 @@ version: 1.5.1
 appVersion: "1.3.1"
 
 # 2.x Version Latest
-#appVersion: "2.0.0-rc1"
+# appVersion: "2.0.0-rc1"
 
 maintainers:
   - name: DandyDeveloper

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.11.1]
+### Added
+- Add optional appVersion for 2.x OpenSearch Release
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.10.2]
 ### Added
 ### Changed
@@ -412,7 +421,8 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.10.2...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.11.1...HEAD
+[1.11.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.10.2...opensearch-1.11.1
 [1.10.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.10.1...opensearch-1.10.2
 [1.10.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.10.0...opensearch-1.10.1
 [1.10.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.9.0...opensearch-1.10.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -22,10 +22,10 @@ version: 1.11.1
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-# 1.x Version Latest
+# 1.x Latest Version
 appVersion: "1.3.1"
 
-# 2.x Version Latest
+# 2.x Latest Version
 # appVersion: "2.0.0-rc1"
 
 maintainers:

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,13 +15,18 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.2
+version: 1.11.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+
+# 1.x Version Latest
 appVersion: "1.3.1"
+
+# 2.x Version Latest
+#appVersion: "2.0.0-rc1"
 
 maintainers:
   - name: DandyDeveloper

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -26,7 +26,7 @@ version: 1.11.1
 appVersion: "1.3.1"
 
 # 2.x Version Latest
-#appVersion: "2.0.0-rc1"
+# appVersion: "2.0.0-rc1"
 
 maintainers:
   - name: DandyDeveloper


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add 2.x appVersion as optional version for helm charts
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1624
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
