### PR TITLE
[Backport 1.x] Add contribution version and branching guides to readme.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
   ## Submitting a Pull Request
 
   Before submitting a pull request make sure you have validated the following:
-  1. Check the [Version and Branching](https://github.com/opensearch-project/.github/blob/main/README.md#version-and-branching) section before commiting a change through PR.
+  1. Check the [Version and Branching](https://github.com/opensearch-project/helm-charts/blob/main/README.md#version-and-branching) section before commiting a change through PR.
   1. All the individual commits in the PR should be signed off. See DCO [section](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) for more details. 
   1. Chart version should be bumped for every code change except docoumentation change. Refer the PR [#179](https://github.com/opensearch-project/helm-charts/pull/179) for an example.
   1. Make sure the PR does not have any merge conflicts. If there are any conflicts please rebase your commits over the code in `main` branch. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@
   ## Submitting a Pull Request
 
   Before submitting a pull request make sure you have validated the following:
+  1. Check the [Version and Branching](https://github.com/opensearch-project/.github/blob/main/README.md#version-and-branching) section before commiting a change through PR.
   1. All the individual commits in the PR should be signed off. See DCO [section](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) for more details. 
   1. Chart version should be bumped for every code change except docoumentation change. Refer the PR [#179](https://github.com/opensearch-project/helm-charts/pull/179) for an example.
   1. Make sure the PR does not have any merge conflicts. If there are any conflicts please rebase your commits over the code in `main` branch. 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 - [OpenSearch Project Helm-Charts](#helm-charts)
 - [Status](#status)
+- [Version and Branching](#version-and-branching)
 - [Installation](#installation)
 - [Change Logs](#change-logs)
 - [Contributing](#contributing)
@@ -18,6 +19,17 @@ A community repository for Helm Charts of OpenSearch Project.
 
 [![Lint and Test Charts](https://github.com/opensearch-project/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/opensearch-project/helm-charts/actions/workflows/lint-test.yaml)
  [![Release Charts](https://github.com/opensearch-project/helm-charts/actions/workflows/release.yaml/badge.svg)](https://github.com/opensearch-project/helm-charts/actions/workflows/release.yaml)
+
+## Version and Branching
+As of now, this helm-charts repository maintains 3 branches:
+* _main_ (Version is 2.x.x for both `version` and `appVersion` in `Chart.yaml`)
+* _1.x_ (Version is 1.x.x for both `version` and `appVersion` in `Chart.yaml`)
+* _gh-pages_ (Reserved branch for publishing helm-charts through github pages)
+<br>
+Contributors should choose the corresponding branch(es) when commiting their change(s):
+* If you have a change for a specific version, only open PR to specific branch
+* If you have a change for all available versions, first open a PR on `main`, then open a backport PR with `[backport 1.x]` in the title, with label `backport 1.x`, etc.
+* No changes should be commited to `gh-pages` by any contributor, as this branch should be only changed by github actions `chart-releaser`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ As of now, this helm-charts repository maintains 3 branches:
 * _1.x_ (Version is 1.x.x for both `version` and `appVersion` in `Chart.yaml`)
 * _gh-pages_ (Reserved branch for publishing helm-charts through github pages)
 <br>
+
 Contributors should choose the corresponding branch(es) when commiting their change(s):
 * If you have a change for a specific version, only open PR to specific branch
 * If you have a change for all available versions, first open a PR on `main`, then open a backport PR with `[backport 1.x]` in the title, with label `backport 1.x`, etc.


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add contribution version and branching guides to readme.md
 
### Issues Resolved
#259
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
