### PR TITLE
added missing secrets on statefulset template

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 ### Added
+- Updated StatefulSet with node_dn.yml and whitelist.yml
 ### Changed
 ### Deprecated
 ### Removed

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -30,5 +30,4 @@ maintainers:
   - name: peterzhuamazon
   - name: prudhvigodithi
   - name: TheAlgo
-  - name: phijojo
   

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -30,4 +30,3 @@ maintainers:
   - name: peterzhuamazon
   - name: prudhvigodithi
   - name: TheAlgo
-  

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.1
+version: 2.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -30,3 +30,5 @@ maintainers:
   - name: peterzhuamazon
   - name: prudhvigodithi
   - name: TheAlgo
+  - name: phijojo
+  

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -190,6 +190,16 @@ spec:
         secret:
           secretName: {{ .Values.securityConfig.tenantsSecret }}
       {{- end }}
+      {{- if .Values.securityConfig.nodesDnSecret }}
+      - name: nodes-dn
+        secret:
+          secretName: {{ .Values.securityConfig.nodesDnSecret }}
+      {{- end }}
+      {{- if .Values.securityConfig.whitelistSecret }}
+      - name: whitelist
+        secret:
+          secretName: {{ .Values.securityConfig.whitelistSecret }}
+      {{- end }}
 {{- if .Values.keystore }}
       - name: keystore
         emptyDir: {}
@@ -226,7 +236,7 @@ spec:
           - 'chown -R 1000:1000 /usr/share/opensearch/data'
         securityContext:
           runAsUser: 0
-        resources: 
+        resources:
            {{ toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
           - name: "{{ template "opensearch.uname" . }}"
@@ -260,7 +270,7 @@ spec:
           cp -a {{ .Values.opensearchHome }}/config/opensearch.keystore /tmp/keystore/
         env: {{ toYaml .Values.extraEnvs | nindent 10 }}
         envFrom: {{ toYaml .Values.envFrom | nindent 10 }}
-        resources: 
+        resources:
            {{ toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
         - name: keystore
@@ -374,6 +384,16 @@ spec:
         - mountPath: {{ .Values.securityConfig.path }}/tenants.yml
           name: tenants
           subPath: tenants.yml
+        {{- end }}
+        {{- if .Values.securityConfig.whitelistSecret }}
+        - mountPath: {{ .Values.securityConfig.path }}/whitelist.yml
+          name: whitelist
+          subPath: whitelist.yml
+        {{- end }}
+        {{- if .Values.securityConfig.nodesDnSecret }}
+        - mountPath: {{ .Values.securityConfig.path }}/nodes_dn.yml
+          name: nodes-dn
+          subPath: nodes_dn.yml
         {{- end }}
         {{- if .Values.securityConfig.config.data }}
         {{-   if .Values.securityConfig.config.dataComplete }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -296,6 +296,8 @@ securityConfig:
   rolesSecret:
   rolesMappingSecret:
   tenantsSecret:
+  nodesDnSecret:
+  whitelistSecret:
   # The following option simplifies securityConfig by using a single secret and
   # specifying the config files as keys in the secret instead of creating
   # different secrets for for each config file.


### PR DESCRIPTION
Signed-off-by: Phijo Jospeh <phijo_jo@yahoo.com>

### Description
The Statefulset template is missing 2 secrets when adding individual secrets.
 
### Issues Resolved
 #191 

### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
