### PR TITLE
[Backport 1.x] Backport 108ef6e to 1.x branch of #172 PR

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,11 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
+## [1.13.0]
+### Added
+- Add feature for readinessProbe and startupProbe
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.12.1]
 ### Added
 ### Changed
 - Update OpenSearch appVersion to 1.3.3.
-
 ### Deprecated
 ### Removed
 ### Fixed
@@ -254,6 +262,7 @@ After deleting the statefulset and upgrading the helm chart again, the new repla
 ### Fixed
 ### Security
 
+<<<<<<< HEAD
 ---
 ## [1.4.3]
 ### Added
@@ -441,6 +450,7 @@ config:
 ### Security
 
 [Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.12.1...HEAD
+[1.12.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.12.0...opensearch-1.12.1
 [1.12.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.12.0...opensearch-1.12.1
 [1.12.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.11.1...opensearch-1.12.0
 [1.11.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.10.2...opensearch-1.11.1

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -449,8 +449,8 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.12.1...HEAD
-[1.12.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.12.0...opensearch-1.12.1
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.13.0...HEAD
+[1.13.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.12.1...opensearch-1.13.0
 [1.12.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.12.0...opensearch-1.12.1
 [1.12.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.11.1...opensearch-1.12.0
 [1.11.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.10.2...opensearch-1.11.1

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -262,7 +262,6 @@ After deleting the statefulset and upgrading the helm chart again, the new repla
 ### Fixed
 ### Security
 
-<<<<<<< HEAD
 ---
 ## [1.4.3]
 ### Added

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.12.1
+version: 1.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/README.md
+++ b/charts/opensearch/README.md
@@ -104,7 +104,10 @@ helm uninstall my-release
 | `transportPort`                    | The transport port that Kubernetes will use for the service. If you change this you will also need to set transport port configuration in `extraEnvs`                                                                                                 | `9300`                                          |
 | `updateStrategy`                   | The [updateStrategy][] for the StatefulSet. By default Kubernetes will wait for the cluster to be green after upgrading each pod. Setting this to `OnDelete` will allow you to manually delete each pod during upgrades                                   | `RollingUpdate`                                 |
 | `volumeClaimTemplate`              | Configuration for the [volumeClaimTemplate for StatefulSets][]. You will want to adjust the storage (default `30Gi` ) and the `storageClassName` if you are using a different storage class                                                               | see [values.yaml][]                             |
-| `extraObjects`                     | Array of extra K8s manifests to deploy                                                                                                                                                                                                                    | list `[]`                                       |
+| `extraObjects`                     | Array of extra K8s manifests to deploy                                                                                                                                                                                                                    | list `[]`                                       |                                   |
+| `readinessProbe`                     | Configuration fields for the readiness [probe][]                                                                                                                                                                               | see [example][] in `values.yaml`
+| `startupProbe`                     | Configuration fields for the [probe][]                                                                                                                                                                               | see [sample][] in `values.yaml`                                     |
+
 
 
 
@@ -161,3 +164,9 @@ helm uninstall my-release
 [service types]: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 
 [topologySpreadConstraints]: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints
+
+[probe]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
+
+[example]: https://github.com/opensearch-project/helm-charts/blob/main/charts/opensearch/values.yaml#L336
+
+[sample]: https://github.com/opensearch-project/helm-charts/blob/main/charts/opensearch/values.yaml#L328

--- a/charts/opensearch/ci/ci-ingress-class-name-values.yaml
+++ b/charts/opensearch/ci/ci-ingress-class-name-values.yaml
@@ -45,6 +45,8 @@ config:
 
     # Bind to all interfaces because we don't know what IP address Docker will assign to us.
     network.host: 0.0.0.0
+    transport.host: localhost
+    transport.tcp.port: 9300
 
     # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
     # discovery.type: single-node
@@ -246,7 +248,7 @@ podManagementPolicy: "Parallel"
 # If you experience slow pod startups you probably want to set this to `false`.
 enableServiceLinks: true
 
-protocol: http
+protocol: https
 httpPort: 9200
 transportPort: 9300
 
@@ -318,12 +320,20 @@ terminationGracePeriod: 120
 
 sysctlVmMaxMapCount: 262144
 
+startupProbe:
+  tcpSocket:
+    port: 9200
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 30
+
 readinessProbe:
   failureThreshold: 3
-  initialDelaySeconds: 10
+  initialDelaySeconds: 900
   periodSeconds: 10
   successThreshold: 3
-  timeoutSeconds: 2000
+  timeoutSeconds: 2
 
 ## Use an alternate scheduler.
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
@@ -402,7 +412,6 @@ fsGroup: ""
 ## Also see: https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/
 sysctl:
   enabled: false
-
 ## Enable to add 3rd Party / Custom plugins not offered in the default OpenSearch image.
 plugins:
   enabled: false

--- a/charts/opensearch/ci/ci-rbac-enabled-values.yaml
+++ b/charts/opensearch/ci/ci-rbac-enabled-values.yaml
@@ -45,6 +45,8 @@ config:
 
     # Bind to all interfaces because we don't know what IP address Docker will assign to us.
     network.host: 0.0.0.0
+    transport.host: localhost
+    transport.tcp.port: 9300
 
     # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
     # discovery.type: single-node
@@ -246,7 +248,7 @@ podManagementPolicy: "Parallel"
 # If you experience slow pod startups you probably want to set this to `false`.
 enableServiceLinks: true
 
-protocol: http
+protocol: https
 httpPort: 9200
 transportPort: 9300
 
@@ -318,12 +320,20 @@ terminationGracePeriod: 120
 
 sysctlVmMaxMapCount: 262144
 
+startupProbe:
+  tcpSocket:
+    port: 9200
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 30
+
 readinessProbe:
   failureThreshold: 3
-  initialDelaySeconds: 10
+  initialDelaySeconds: 900
   periodSeconds: 10
   successThreshold: 3
-  timeoutSeconds: 2000
+  timeoutSeconds: 2
 
 ## Use an alternate scheduler.
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/

--- a/charts/opensearch/ci/ci-values.yaml
+++ b/charts/opensearch/ci/ci-values.yaml
@@ -45,6 +45,8 @@ config:
 
     # Bind to all interfaces because we don't know what IP address Docker will assign to us.
     network.host: 0.0.0.0
+    transport.host: localhost
+    transport.tcp.port: 9300
 
     # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
     # discovery.type: single-node
@@ -248,7 +250,7 @@ podManagementPolicy: "Parallel"
 # If you experience slow pod startups you probably want to set this to `false`.
 enableServiceLinks: true
 
-protocol: http
+protocol: https
 httpPort: 9200
 transportPort: 9300
 
@@ -319,13 +321,6 @@ securityConfig:
 terminationGracePeriod: 120
 
 sysctlVmMaxMapCount: 262144
-
-readinessProbe:
-  failureThreshold: 3
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  successThreshold: 3
-  timeoutSeconds: 2000
 
 ## Use an alternate scheduler.
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -299,8 +299,15 @@ spec:
 
           bash opensearch-docker-entrypoint.sh
       {{- end }}
+  
         image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 10 }}
+      {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.Version }}
+        startupProbe:
+{{ toYaml .Values.startupProbe | indent 10 }}
+      {{- end }}
         ports:
         - name: http
           containerPort: {{ .Values.httpPort }}
@@ -430,7 +437,7 @@ spec:
               local path="${1}"
               if [ -n "${USERNAME}" ] && [ -n "${PASSWORD}" ]; then
                 BASIC_AUTH="-u ${USERNAME}:${PASSWORD}"
-              elses
+              else
                 BASIC_AUTH=''
               fi
               curl -XGET -s -k --fail ${BASIC_AUTH} {{ .Values.protocol }}://{{ template "opensearch.masterService" . }}:{{ .Values.httpPort }}${path}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -250,7 +250,7 @@ podManagementPolicy: "Parallel"
 # If you experience slow pod startups you probably want to set this to `false`.
 enableServiceLinks: true
 
-protocol: http
+protocol: https
 httpPort: 9200
 transportPort: 9300
 
@@ -323,12 +323,19 @@ terminationGracePeriod: 120
 
 sysctlVmMaxMapCount: 262144
 
-readinessProbe:
-  failureThreshold: 3
-  initialDelaySeconds: 10
+startupProbe:
+  tcpSocket:
+    port: 9200
+  initialDelaySeconds: 5
   periodSeconds: 10
-  successThreshold: 3
-  timeoutSeconds: 2000
+  timeoutSeconds: 3
+  failureThreshold: 30
+readinessProbe:
+  tcpSocket:
+    port: 9200
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
 
 ## Use an alternate scheduler.
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,3 +1,3 @@
 # See https://github.com/helm/chart-testing#configuration
 target-branch: 1.x
-helm-extra-args: --timeout 800s
+helm-extra-args: --timeout 1000s


### PR DESCRIPTION
### Description
Backport 108ef6e to 1.x branch of #172 PR
 
### Issues Resolved
#172 backport
 
### Check List
- [ ] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
