### PR TITLE
allow to disable security context

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.4.0]
+### Added
+- Support for deploying without securityContexts
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [2.3.0]
 ### Added
 - - Updated version to 2.3.0 and appVersion to "2.1.0".

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -64,6 +64,7 @@ spec:
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}
+      {{- if not .Values.disableSecurityContexts }}
       securityContext:
 {{ toYaml .Values.podSecurityContext | indent 8 }}
         {{- if .Values.sysctl.enabled }}
@@ -74,6 +75,7 @@ spec:
         {{- if .Values.fsGroup }}
         fsGroup: {{ .Values.fsGroup }} # Deprecated value, please use .Values.podSecurityContext.fsGroup
         {{- end }}
+      {{- end }}
       {{- if and .Values.rbac.create (eq .Values.rbac.serviceAccountName "") }}
       serviceAccountName: "{{ template "opensearch.uname" . }}"
       {{- else }}
@@ -224,8 +226,10 @@ spec:
         command: ['sh', '-c']
         args:
           - 'chown -R 1000:1000 /usr/share/opensearch/data'
+        {{- if not .Values.disableSecurityContexts }}
         securityContext:
           runAsUser: 0
+        {{- end }}
         resources: 
            {{ toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
@@ -283,8 +287,10 @@ spec:
       {{- end }}
       containers:
       - name: "{{ template "opensearch.name" . }}"
+      {{- if not .Values.disableSecurityContexts }}
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
+      {{- end }}
       {{- if .Values.plugins.enabled }}
         command:
         - sh

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -275,6 +275,10 @@ updateStrategy: RollingUpdate
 # of your pods to be unavailable during maintenance
 maxUnavailable: 1
 
+# Disables the podSecurityContext and securityContext to allow running
+# on openshift with automated security context
+disableSecurityContexts: false
+
 podSecurityContext:
   fsGroup: 1000
   runAsUser: 1000


### PR DESCRIPTION
required for openshift deployments

### Description
Running Opensearch via Helm charts on Openshift is currently non trivial. Openshift manages UID and GID of each container per default and ensures it's not running as root.
 
### Issues Resolved
#285 
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
