### PR TITLE
opensearch-dashboards configmap rendering fix

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -58,7 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.1...HEAD
+[2.2.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.0...opensearch-dashboards-2.2.1
 [2.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.1.0...opensearch-dashboards-2.2.0
 [2.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.0.1...opensearch-dashboards-2.1.0
 [2.0.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.0.0...opensearch-dashboards-2.0.1

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.2.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Opensearch dashboard config map format is restored with backward support of string format
+### Security
+---
 ## [2.2.0]
 ### Added
 ### Changed

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/configmap.yaml
+++ b/charts/opensearch-dashboards/templates/configmap.yaml
@@ -5,7 +5,13 @@ metadata:
   name: {{ template "opensearch-dashboards.fullname" . }}-config
   labels: {{ include "opensearch-dashboards.labels" . | nindent 4 }}
 data:
-{{- range $configName, $configYaml := .Values.config }}
-  {{ $configName }}: {{- toYaml $configYaml | nindent 4 }}
+{{- range $configName, $configContent := .Values.config }}
+  {{- if eq (kindOf $configContent) "map" }}
+  {{ $configName }}: |
+    {{- toYaml $configContent | nindent 4 }}
+  {{- else }}
+  {{ $configName }}:
+    {{- $configContent | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Boris Komraz <bkomraz1@gmail.com>

### Description
Opensearch dashboard config map format is restored with backward support of string format
 
### Issues Resolved
https://github.com/opensearch-project/helm-charts/issues/288
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
