### PR TITLE
[backport 1.x] Opensearch dashboard configmap error: invalid type for io.k8s.api.core.v1.ConfigMap.data: got "map", expected "string"

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
-- Opensearch dashboard fix issue #295
-- Opensearch dashboard config map support both string and map format
+- Opensearch dashboard fix issue #295.
+- Opensearch dashboard config map support both string and map format.
 ### Security
 ---
 ## [1.7.1]

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.7.2]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Opensearch dashboard fix issue #295.
+- Opensearch dashboard config map support both string and map format.
+### Security
+---
 ## [1.7.1]
 ### Added
 ### Changed
@@ -242,7 +252,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.7.1...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.7.2...HEAD
+[1.7.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.7.1...opensearch-1.7.2
 [1.7.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.7.0...opensearch-1.7.1
 [1.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.6.1...opensearch-1.7.0
 [1.6.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.6.0...opensearch-1.6.1

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
-- Opensearch dashboard fix issue #295.
-- Opensearch dashboard config map support both string and map format.
+- Opensearch dashboard fix issue #295
+- Opensearch dashboard config map support both string and map format
 ### Security
 ---
 ## [1.7.1]

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.1
+version: 1.7.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/configmap.yaml
+++ b/charts/opensearch-dashboards/templates/configmap.yaml
@@ -5,13 +5,13 @@ metadata:
   name: {{ template "opensearch-dashboards.fullname" . }}-config
   labels: {{ include "opensearch-dashboards.labels" . | nindent 4 }}
 data:
-{{- range $configName, $configContent := .Values.config }}
-  {{- if eq (kindOf $configContent) "map" }}
+{{- range $configName, $configYaml := .Values.config }}
+{{- if eq (kindOf $configYaml) "map" }}
   {{ $configName }}: |
-    {{- toYaml $configContent | nindent 4 }}
+    {{- toYaml $configYaml | nindent 4 }}
   {{- else }}
-  {{ $configName }}:
-    {{- $configContent | nindent 4 }}
-  {{- end }}
-{{- end }}
+  {{ $configName }}: |
+{{ tpl $configYaml $ | indent 4 -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
### Description
Opensearch dashboard config map support both string and map format.
 
### Issues Resolved
https://github.com/opensearch-project/helm-charts/issues/295
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
