### PR TITLE
Opensearch dashboards ingress template fix to allow named port

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.4.2]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- OpenSearch Dashboards fixed failure when ingress service port is a string (named port)
+### Security
+---
 ## [2.4.1]
 ### Added
 - Helm chart-releaser parallel release issue, updated version to 2.4.1.

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.1
+version: 2.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/ingress.yaml
+++ b/charts/opensearch-dashboards/templates/ingress.yaml
@@ -46,7 +46,11 @@ spec:
               service:
                 name: {{ .backend.serviceName | default $fullName }}
                 port:
+                  {{- if and .backend.servicePort (kindIs "string" .backend.servicePort) }}
+                  name: {{ .backend.servicePort }}
+                  {{- else -}}
                   number: {{ .backend.servicePort | default $svcPort }}
+                  {{- end }}
           {{- end }}
     {{- end }}
   {{- else -}}


### PR DESCRIPTION
### Description
Fix OpenSearch dashboards ingress template to allow named port or port number when `apiVersion: networking.k8s.io/v1`
Based on documentation: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
- sets `service.port.name` when value of `servicePort` is non empty string
- sets `service.port.number` when `servicePort` empty or non string
 
### Issues Resolved
#314 
When setting value `ingress.hosts[0].paths[0].backend.servicePort` as named port or `use-annotation` (to take configuration from annotations) getting error:
`Error: error validating "": error validating data: ValidationError(Ingress.spec.rules[0].http.paths[0].backend.service.port.number): invalid type for io.k8s.api.networking.v1.ServiceBackendPort.number: got "string", expected "integer"`
Etc: Using annotations to configure redirect from examples: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/ingress/annotations/
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
