### PR TITLE
Resolve Kind Cluster not able to be built in PR checks

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: ["1.14.10", "1.18.19", "1.19.11", "1.21.2", "1.22.2"]
+        k8s: ["1.14.10", "1.18.19", "1.19.11", "1.21.2", "1.22.2", "1.23.14", "1.24.8", "1.25.4"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -17,6 +17,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v1.1
+        # as of 2022/12 the set-output still not fixed in this action
+        # https://github.com/Azure/setup-helm/issues/103
         with:
           version: v3.7.0
 
@@ -32,17 +34,17 @@ jobs:
         run: |
           changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "CHART_CHANGED=true" >> $GITHUB_ENV
           fi
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.4.0
         with:
           node_image: kindest/node:v${{ matrix.k8s }}
-        if: steps.list-changed.outputs.changed == 'true'
+        if: ${{ env.CHART_CHANGED == 'true' }}
 
       # See https://github.com/helm/chart-testing/blob/main/doc/ct_install.md
       - name: Run chart-testing (install)


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Resolve Kind Cluster not able to be built in PR checks
 
### Issues Resolved
#355
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
