### PR TITLE
Update kind actions with correct kubectl version and remove 1.14 and 1.18 support

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: ["1.14.10", "1.18.19", "1.19.11", "1.21.2", "1.22.2"]
+        k8s: ["1.19.16", "1.21.14", "1.22.9", "1.23.12", "1.24.7", "1.25.2"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -17,6 +17,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v1.1
+        # as of 2022/12 the set-output still not fixed in this action
+        # https://github.com/Azure/setup-helm/issues/103
         with:
           version: v3.7.0
 
@@ -32,17 +34,18 @@ jobs:
         run: |
           changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "CHART_CHANGED=true" >> $GITHUB_ENV
           fi
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.4.0
         with:
           node_image: kindest/node:v${{ matrix.k8s }}
-        if: steps.list-changed.outputs.changed == 'true'
+          kubectl_version: v${{ matrix.k8s }}
+        if: ${{ env.CHART_CHANGED == 'true' }}
 
       # See https://github.com/helm/chart-testing/blob/main/doc/ct_install.md
       - name: Run chart-testing (install)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Contributors should choose the corresponding branch(es) when commiting their cha
 * If you have a change for all available versions, first open a PR on `main`, then open a backport PR with `[backport 1.x]` in the title, with label `backport 1.x`, etc.
 * No changes should be commited to `gh-pages` by any contributor, as this branch should be only changed by github actions `chart-releaser`
 
+## Kuvernetes Version Support
+* This helm-chart repository is tested with kubernetes version 1.19 and above
+
 ## Installation
 
 To install the OpenSearch Helm charts, execute the following commands:


### PR DESCRIPTION
### Description
Update kind actions with correct kubectl version and remove 1.14 and 1.18 support
 
### Issues Resolved
#355
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
