### PR TITLE
[Backport 1.x]allow adding plugins and change defaultmode for opensearch dashboards

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -121,7 +121,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-<<<<<<< HEAD
 ---
 ## [1.6.1]
 ### Added

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.9.1]
+### Added
+- Added the ability to define plugins on node startup via plugins.enabled option for opensearch-dashboards chart.
+- Added the ability to define defaultMode for the opensearch_dashboards.yml file which is mounted as configMap
+- Added documentation for new configurations
+### Changed
+- Updated version to 1.9.1
+---
 ## [1.9.0]
 ### Added
 ### Changed
@@ -113,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+<<<<<<< HEAD
 ---
 ## [1.6.1]
 ### Added
@@ -324,7 +333,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.9.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.9.1...HEAD
+[1.9.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.4...opensearch-1.9.1
 [1.9.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.4...opensearch-1.9.0
 [1.8.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.3...opensearch-1.8.4
 [1.8.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.8.2...opensearch-1.8.3
@@ -357,3 +367,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.5]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.4...opensearch-1.0.5
 [1.0.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.2...opensearch-1.0.4
 [1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.0.1...opensearch-dashboards-1.0.2
+

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.0
+version: 1.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/README.md
+++ b/charts/opensearch-dashboards/README.md
@@ -79,7 +79,9 @@
 | `livenessProbe`                     | Configuration fields for the liveness [probe][]                                                                                                                                                                               | see [exampleLiveness][] in `values.yaml`
 | `readinessProbe`                     | Configuration fields for the readiness [probe][]                                                                                                                                                                               | see [exampleReadiness][] in `values.yaml`
 | `startupProbe`                     | Configuration fields for the startup [probe][]                                                                                                                                                                               | see [exampleStartup][] in `values.yaml`                                     |
-
+| `plugins.enabled`                     | Allow/disallow to add 3rd Party / Custom plugins not offered in the default OpenSearchDashboards image                    | false  |
+| `plugins.installList`                 | Array containing the Opensearch Dashboards plugins to be installed in container	                                        |   []   |
+| `opensearchDashboardsYml.defaultMode` | Allow you to set the defaultMode for the opensearch_dashboards.yml mounted as configMap                                   |        |
 
 [probe]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
 

--- a/charts/opensearch-dashboards/templates/deployment.yaml
+++ b/charts/opensearch-dashboards/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         - name: config
           configMap:
             name: {{ template "opensearch-dashboards.fullname" . }}-config
+            {{- if .Values.opensearchDashboardsYml.defaultMode }}
+            defaultMode: {{ .Values.opensearchDashboardsYml.defaultMode }}
+            {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes }}
         # Currently some extra blocks accept strings
@@ -151,6 +154,18 @@ spec:
         - containerPort: {{ .Values.service.port }}
           name: {{ .Values.service.httpPortName | default "http" }}
           protocol: TCP
+{{- if .Values.plugins.enabled }}
+        command:
+          - sh
+          - -c
+          - |
+            #!/usr/bin/bash
+            set -e
+            {{- range $plugin := .Values.plugins.installList }}
+            ./bin/opensearch-dashboards-plugin install {{ $plugin }}
+            {{- end }}
+            bash opensearch-dashboards-docker-entrypoint.sh opensearch-dashboards
+{{- end }}
 {{- if .Values.lifecycle }}
         lifecycle:
 {{ toYaml .Values.lifecycle | indent 10 }}

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -122,6 +122,10 @@ config: {}
     #     certificateAuthorities: /usr/share/opensearch-dashboards/certs/dashboards-root-ca.pem
     #     if utilizing custom CA certs for connection to opensearch, provide the CA here
 
+opensearchDashboardsYml:
+  defaultMode:
+  # value should be 0-0777
+
 priorityClassName: ""
 
 opensearchAccount:
@@ -237,3 +241,9 @@ lifecycle: {}
   #       - |
   #         #!/bin/bash
   #         curl -I "http://admin:admin@127.0.0.1:5601/status -H "kbn-xsrf: true" -H 'kbn-xsrf: true' -H "Content-Type: application/json"
+
+## Enable to add 3rd Party / Custom plugins not offered in the default OpenSearchDashboards image.
+plugins:
+  enabled: false
+  installList: []
+  # - example-fake-plugin-downloadable-url

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.16.1]
+### Added
+- added "plugins.enabled" and "plugins.installList" to the readme
+### Changed
+- Bumped version to 2.8.1
+---
 ## [1.16.0]
 ### Added
 - Add option to enable the use of `sysctlInit` to set sysctl vm.max_map_count through privileged `initContainer`. See: [Issue #87](https://github.com/opensearch-project/helm-charts/issues/87)
@@ -335,6 +341,7 @@ After deleting the statefulset and upgrading the helm chart again, the new repla
 - Fixed links to values.yaml in README.md.
 ### Security
 
+<<<<<<< HEAD
 ---
 ## [1.4.2]
 ### Added
@@ -511,7 +518,8 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.16.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.16.1...HEAD
+[1.16.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.15.0...opensearch-1.16.1
 [1.16.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.15.0...opensearch-1.16.0
 [1.15.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.14.2...opensearch-1.15.0
 [1.14.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.14.1...opensearch-1.14.2
@@ -564,3 +572,4 @@ config:
 [1.0.5]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.4...opensearch-1.0.5
 [1.0.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.2...opensearch-1.0.4
 [1.0.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.0.1...opensearch-1.0.2
+

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - added "plugins.enabled" and "plugins.installList" to the readme
 ### Changed
-- Bumped version to 2.8.1
+- Bumped version to 1.16.1
 ---
 ## [1.16.0]
 ### Added
@@ -341,7 +341,6 @@ After deleting the statefulset and upgrading the helm chart again, the new repla
 - Fixed links to values.yaml in README.md.
 ### Security
 
-<<<<<<< HEAD
 ---
 ## [1.4.2]
 ### Added

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.0
+version: 1.16.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/README.md
+++ b/charts/opensearch/README.md
@@ -109,7 +109,8 @@ helm uninstall my-release
 | `livenessProbe`                     | Configuration fields for the liveness [probe][]                                                                                                                                                                               | see [exampleLiveness][] in `values.yaml`
 | `readinessProbe`                     | Configuration fields for the readiness [probe][]                                                                                                                                                                               | see [exampleReadiness][] in `values.yaml`
 | `startupProbe`                     | Configuration fields for the startup [probe][]                                                                                                                                                                               | see [exampleStartup][] in `values.yaml`                                     |
-
+| `plugins.enabled`                     | Allow/disallow to add 3rd Party / Custom plugins not offered in the default OpenSearchDashboards image                    | false  |
+| `plugins.installList`                 | Array containing the Opensearch Dashboards plugins to be installed in container	                                        |   []   |
 
 
 


### PR DESCRIPTION
### Description
Similar to https://github.com/opensearch-project/helm-charts/pull/71 , the change would allow installing external plugins when container starts for opensearch dashboards.
In addition, this change allows to specify defaultMode for the opensearch_dashboards.yml file which is mounted as configmap
Changelog and Readme are updated.
Changes were tested using k8s cluster using the chart 
### Issues Resolved
This change is a backport
 
### Check List
- [X] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [X] Helm chart version bumped
- [X] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
