### PR TITLE
Add lifecycle support in opensearch container

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.10.1]
+### Added
+- Support for lifecycle in the opensearch container in the StatefulSet
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [2.10.0]
 ### Added
 ### Changed

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.0
+version: 2.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/README.md
+++ b/charts/opensearch/README.md
@@ -2,10 +2,11 @@
 
 This Helm chart installs [OpenSearch](https://github.com/opensearch-project/OpenSearch) with configurable TLS, RBAC and much more configurations. This chart caters a number of different use cases and setups.
 
-- [Requirements](#requirements)
-- [Installing](#installing)
-- [Uninstalling](#uninstalling)
-- [Configuration](#configuration)
+- [OpenSearch Helm Chart](#opensearch-helm-chart)
+  - [Requirements](#requirements)
+  - [Installing](#installing)
+  - [Uninstalling](#uninstalling)
+  - [Configuration](#configuration)
 
 ## Requirements
 
@@ -113,7 +114,7 @@ helm uninstall my-release
 | `startupProbe`                     | Configuration fields for the startup [probe][]                                                                                                                                                                               | see [exampleStartup][] in `values.yaml`                                     |
 | `plugins.enabled`                     | Allow/disallow to add 3rd Party / Custom plugins not offered in the default OpenSearchDashboards image                    | false  |
 | `plugins.installList`                 | Array containing the Opensearch Dashboards plugins to be installed in container	                                        |   []   |
-
+| `opensearchLifecycle`              | Allows you to configure lifecycle hooks for the OpenSearch container in the StatefulSet                                                                                                                                                                   | {}                                              |
 
 
 [anti-affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -379,6 +379,10 @@ spec:
         envFrom:
 {{ toYaml .Values.envFrom | indent 8 }}
 {{- end }}
+{{- if .Values.opensearchLifecycle }}
+        lifecycle:
+{{ toYaml .Values.opensearchLifecycle | indent 10 }}
+{{- end }}
         volumeMounts:
         {{- if .Values.persistence.enabled }}
         - name: "{{ template "opensearch.uname" . }}"

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -388,6 +388,8 @@ fullnameOverride: ""
 
 masterTerminationFix: false
 
+opensearchLifecycle: {}
+
 lifecycle: {}
   # preStop:
   #   exec:

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -389,6 +389,12 @@ fullnameOverride: ""
 masterTerminationFix: false
 
 opensearchLifecycle: {}
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sh", "-c", "echo Hello from the preStart handler > /usr/share/message"]
+  # postStart:
+  #   exec:
+  #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
 
 lifecycle: {}
   # preStop:


### PR DESCRIPTION
### Description
I was looking to run the securityadmin.sh script automatically after the opensearch container is started up. However, the opensearch container in the StatefulSet did not have 'lifecycle' support. Added support to satisfy my use case, in addition to adding extra customization options to the chart.
 
### Issues Resolved
- [Enhancement][OpenSearch] #395
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
