### PR TITLE
Fixing opensearch helmchart conditions when there is only cluster_manager role specified to nodes

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.10.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- masterTerminationFix option when cluster_manager is specified
+- singleNode condition cluster_manager is specified 
+### Security
+---
+---
 ## [2.10.0]
 ### Added
 ### Changed

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.0
+version: 2.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -354,7 +354,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        {{- if (and (has "master" .Values.roles) (not .Values.singleNode)) }}
+        {{- if (and (or (has "master" .Values.roles) (has "cluster_manager" .Values.roles)) (not .Values.singleNode)) }}
         - name: cluster.initial_master_nodes
           value: "{{ template "opensearch.endpoints" . }}"
         {{- end }}
@@ -459,7 +459,7 @@ spec:
         {{- end }}
         {{- end }}
       {{- if .Values.masterTerminationFix }}
-      {{- if has "master" .Values.roles }}
+      {{- if or (has "master" .Values.roles) (has "cluster_manager" .Values.roles) }}
       # This sidecar will prevent slow master re-election
       - name: opensearch-master-graceful-termination-handler
         image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
### Description
As new opensearch role for nodes was introduce helmchart templates should be adjusted. I Fixed opensearch helmchart conditions when there is no master role specified to nodes. 
### Issues Resolved
[List any issues this PR will resolve. You should likely open an issue if one does not already exist.]
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
