### PR TITLE
fix: Avoid CrashLoop when keystore secret has no data

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.13.2]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Avoid CrashLoop when keystore secret has no data
+### Security
+---
 ## [2.13.1]
 ### Added
 - Support string type for extraObjects
@@ -284,7 +293,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.1...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.2...HEAD
+[2.13.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.1...opensearch-2.13.2
 [2.13.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.0...opensearch-2.13.1
 [2.13.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.12.0...opensearch-2.13.0
 [2.12.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.5...opensearch-2.12.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.13.1
+version: 2.13.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -240,9 +240,8 @@ spec:
           - 'chown -R 1000:1000 /usr/share/opensearch/data'
         securityContext:
           runAsUser: 0
-        resources: 
+        resources:
           {{- toYaml .Values.initResources | nindent 10 }}
-
         volumeMounts:
           - name: "{{ template "opensearch.uname" . }}"
             mountPath: {{ .Values.opensearchHome }}/data
@@ -267,7 +266,7 @@ spec:
         resources:
           {{- toYaml .Values.initResources | nindent 10 }}
 {{- end }}
-{{ if .Values.keystore }}
+{{- if .Values.keystore }}
       - name: keystore
         image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
@@ -281,6 +280,7 @@ spec:
           {{ .Values.opensearchHome }}/bin/opensearch-keystore create
 
           for i in /tmp/keystoreSecrets/*/*; do
+            [ -f "$file" ] || continue
             key=$(basename $i)
             echo "Adding file $i to keystore key $key"
             {{ .Values.opensearchHome }}/bin/opensearch-keystore add-file "$key" "$i"
@@ -296,7 +296,7 @@ spec:
         env: {{ toYaml .Values.extraEnvs | nindent 10 }}
         envFrom: {{ toYaml .Values.envFrom | nindent 10 }}
         resources:
-           {{ toYaml .Values.initResources | nindent 10 }}
+          {{- toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
         - name: keystore
           mountPath: /tmp/keystore
@@ -304,7 +304,7 @@ spec:
         - name: keystore-{{ .secretName }}
           mountPath: /tmp/keystoreSecrets/{{ .secretName }}
         {{- end }}
-{{ end }}
+{{- end }}
       {{- if .Values.extraInitContainers }}
       # Currently some extra blocks accept strings
       # to continue with backwards compatibility this is being kept
@@ -361,7 +361,7 @@ spec:
         - name: metrics
           containerPort: {{ .Values.metricsPort }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+          {{- toYaml .Values.resources | nindent 10 }}
         env:
         - name: node.name
           valueFrom:
@@ -517,7 +517,7 @@ spec:
           sleep infinity &
           wait $!
         resources:
-{{ toYaml .Values.sidecarResources | indent 10 }}
+          {{- toYaml .Values.sidecarResources | nindent 10 }}
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
### Description
When a keystore secret is configured and it does not have any entries, the shell script incorrectly attempts to import a non-existent file due to fileglobbing.
 
### Issues Resolved
#433 
 
### Check List
- [X] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [X] Helm chart version bumped
- [X] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
