### PR TITLE
[Backport 1.x] Support string type for extraObjects (#441)

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.13.1]
+### Added
+- Support string type for extraObjects
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.13.0]
 ### Added
 ### Changed
@@ -385,7 +394,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.13.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.13.1...HEAD
+[1.13.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.13.0...opensearch-1.13.1
 [1.13.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.12.2...opensearch-1.13.0
 [1.12.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.12.1...opensearch-1.12.2
 [1.12.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.12.0...opensearch-1.12.1

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.13.0
+version: 1.13.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/extraManifests.yaml
+++ b/charts/opensearch-dashboards/templates/extraManifests.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
-{{ tpl (toYaml .) $ }}
+{{- if typeIs "string" . }}
+{{- tpl . $ }}
+{{- else }}
+{{- tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -237,6 +237,18 @@ extraObjects: []
   #       type: Opaque
   #       labels:
   #         app.kubernetes.io/part-of: argocd
+  # - |
+  #    apiVersion: policy/v1
+  #    kind: PodDisruptionBudget
+  #    metadata:
+  #      name: {{ template "opensearch-dashboards.fullname" . }}
+  #      labels:
+  #        {{- include "opensearch-dashboards.labels" . | nindent 4 }}
+  #    spec:
+  #      minAvailable: 1
+  #      selector:
+  #        matchLabels:
+#          {{- include "opensearch-dashboards.selectorLabels" . | nindent 6 }}
 
 # pod lifecycle policies as outlined here:
 # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.20.2]
+### Added
+- Support string type for extraObjects
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.20.1]
 ### Added
 - Option for automountServiceAccountToken
@@ -591,7 +600,9 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.20.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.20.2...HEAD
+[1.20.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.20.1...opensearch-1.20.2
+[1.20.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.20.0...opensearch-1.20.1
 [1.20.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.19.2...opensearch-1.20.0
 [1.19.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.19.1...opensearch-1.19.2
 [1.19.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.19.0...opensearch-1.19.1

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.20.1
+version: 1.20.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/extraManifests.yaml
+++ b/charts/opensearch/templates/extraManifests.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
-{{ tpl (toYaml .) $ }}
+{{- if typeIs "string" . }}
+{{- tpl . $ }}
+{{- else }}
+{{- tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -497,3 +497,15 @@ extraObjects: []
   #       type: Opaque
   #       labels:
   #         app.kubernetes.io/part-of: argocd
+  # - |
+  #    apiVersion: policy/v1
+  #    kind: PodDisruptionBudget
+  #    metadata:
+  #      name: {{ template "opensearch.uname" . }}
+  #      labels:
+  #        {{- include "opensearch.labels" . | nindent 4 }}
+  #    spec:
+  #      minAvailable: 1
+  #      selector:
+  #        matchLabels:
+  #          {{- include "opensearch.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
### Description
As requested, this feature from issue https://github.com/opensearch-project/helm-charts/pull/428 is now backported into v1
 
### Issues Resolved
#428 
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
