### PR TITLE
[Backport 1.x] Avoid CrashLoop when keystore secret has no data

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.20.3]
+### Added
+- Avoid CrashLoop when keystore secret has no data
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.20.2]
 ### Added
 - Support string type for extraObjects
@@ -307,7 +316,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
-- Fixed `image.pullPolicy` Helm value not setting the `imagePullPolicy` for the "opensearch" container 
+- Fixed `image.pullPolicy` Helm value not setting the `imagePullPolicy` for the "opensearch" container
 ### Security
 ---
 ## [1.7.0]
@@ -600,7 +609,8 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.20.2...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.20.3...HEAD
+[1.20.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.20.2...opensearch-1.20.3
 [1.20.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.20.1...opensearch-1.20.2
 [1.20.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.20.0...opensearch-1.20.1
 [1.20.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.19.2...opensearch-1.20.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.20.2
+version: 1.20.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -208,7 +208,7 @@ spec:
       - name: keystore-{{ .secretName }}
         secret: {{ toYaml . | nindent 12 }}
       {{- end }}
-{{ end }}
+{{- end }}
       {{- if .Values.extraVolumes }}
       # Currently some extra blocks accept strings
       # to continue with backwards compatibility this is being kept
@@ -237,8 +237,8 @@ spec:
           - 'chown -R 1000:1000 /usr/share/opensearch/data'
         securityContext:
           runAsUser: 0
-        resources: 
-           {{ toYaml .Values.initResources | nindent 10 }}
+        resources:
+           {{- toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
           - name: "{{ template "opensearch.uname" . }}"
             mountPath: {{ .Values.opensearchHome }}/data
@@ -261,9 +261,9 @@ spec:
           runAsUser: 0
           privileged: true
         resources:
-           {{ toYaml .Values.initResources | nindent 10 }}
+           {{- toYaml .Values.initResources | nindent 10 }}
 {{- end }}
-{{ if .Values.keystore }}
+{{- if .Values.keystore }}
       - name: keystore
         image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
@@ -277,6 +277,7 @@ spec:
           {{ .Values.opensearchHome }}/bin/opensearch-keystore create
 
           for i in /tmp/keystoreSecrets/*/*; do
+            [ -f "$i" ] || continue
             key=$(basename $i)
             echo "Adding file $i to keystore key $key"
             {{ .Values.opensearchHome }}/bin/opensearch-keystore add-file "$key" "$i"
@@ -291,8 +292,8 @@ spec:
           cp -a {{ .Values.opensearchHome }}/config/opensearch.keystore /tmp/keystore/
         env: {{ toYaml .Values.extraEnvs | nindent 10 }}
         envFrom: {{ toYaml .Values.envFrom | nindent 10 }}
-        resources: 
-           {{ toYaml .Values.initResources | nindent 10 }}
+        resources:
+           {{- toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
         - name: keystore
           mountPath: /tmp/keystore
@@ -300,7 +301,7 @@ spec:
         - name: keystore-{{ .secretName }}
           mountPath: /tmp/keystoreSecrets/{{ .secretName }}
         {{- end }}
-{{ end }}
+{{- end }}
       {{- if .Values.extraInitContainers }}
       # Currently some extra blocks accept strings
       # to continue with backwards compatibility this is being kept
@@ -330,7 +331,7 @@ spec:
 
           bash opensearch-docker-entrypoint.sh
       {{- end }}
-  
+
         image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         readinessProbe:
@@ -357,7 +358,7 @@ spec:
         - name: metrics
           containerPort: {{ .Values.metricsPort }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+          {{- toYaml .Values.resources | nindent 10 }}
         env:
         - name: node.name
           valueFrom:
@@ -513,7 +514,7 @@ spec:
           sleep infinity &
           wait $!
         resources:
-{{ toYaml .Values.sidecarResources | indent 10 }}
+          {{- toYaml .Values.sidecarResources | nindent 10 }}
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
### Description
When a keystore secret is configured and it does not have any entries, the shell script incorrectly attempts to import a non-existent file due to fileglobbing.
 
### Issues Resolved
https://github.com/opensearch-project/helm-charts/issues/433
 
### Check List
- [X] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [X] Helm chart version bumped
- [X] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
