### PR TITLE
Use the loop variable in keystore init script

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.13.3]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Fix the keystore init script by using the loop variable
+### Security
+---
 ## [2.13.2]
 ### Added
 ### Changed

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.13.2
+version: 2.13.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -280,7 +280,7 @@ spec:
           {{ .Values.opensearchHome }}/bin/opensearch-keystore create
 
           for i in /tmp/keystoreSecrets/*/*; do
-            [ -f "$file" ] || continue
+            [ -f "$i" ] || continue
             key=$(basename $i)
             echo "Adding file $i to keystore key $key"
             {{ .Values.opensearchHome }}/bin/opensearch-keystore add-file "$key" "$i"


### PR DESCRIPTION
### Description
The keystore init script use an undeclared variable instead of the loop (i) variable to check the file existence.
 
### Check List
- [X] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [X] Helm chart version bumped
- [X] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
