### PR TITLE
Allow overriding of `pathType` in ingress rules to support ImplementationSpecific

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 ### Added
+- Support `pathType` for ingress rules
 ### Changed
 ### Deprecated
 ### Removed

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.0
+version: 1.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/ingress.yaml
+++ b/charts/opensearch-dashboards/templates/ingress.yaml
@@ -44,7 +44,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            pathType: Prefix
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ .backend.serviceName | default $fullName }}

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -177,6 +177,7 @@ ingress:
     - host: chart-example.local
       paths:
         - path: /
+          pathType: Prefix
           backend:
             serviceName: ""
             servicePort: ""

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 ### Added
+- Support `pathType` for ingress rules
 ### Changed
 ### Deprecated
 ### Removed

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.22.0
+version: 1.23.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/ingress.yaml
+++ b/charts/opensearch/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := include "opensearch.serviceName" . -}}
 {{- $servicePort := .Values.httpPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $ingressApiIsStable := eq (include "opensearch.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsIngressClassName := eq (include "opensearch.ingress.supportsIngressClassName" .) "true" -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -41,7 +42,7 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
-            pathType: Prefix
+            pathType: {{ $ingressPathType }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -389,6 +389,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /
+  pathType: Prefix
   hosts:
     - chart-example.local
   tls: []


### PR DESCRIPTION
Depending on implementation of ingressClass, hardcoded value `Prefix` for `pathType` of rules won't work and `ImplementationSpecific` should be specified instead.

This change add a new parameter for both helm charts for `opensearch` and `opensearch-dashboards`

* `opensearch` gets `pathType: Prefix` along with the existing `path: /` in `value.yaml`
* `opensearch-dashboards` gets `pathType: Prefix` in `ingress.hosts.paths` array and defaults to `Prefix` in the template `ingress.yaml` and the default rule specified in `values.yaml`.

### Description
[Describe what this change achieves.]
 
### Issues Resolved
[List any issues this PR will resolve. You should likely open an issue if one does not already exist.]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
