### PR TITLE
fix(opensearch-dashboards) - use selectorLabels

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- Use the selectorLabels instead of the static defined app and chart
 ### Security
 ---
 ## [2.14.0]

--- a/charts/opensearch-dashboards/templates/deployment.yaml
+++ b/charts/opensearch-dashboards/templates/deployment.yaml
@@ -12,17 +12,10 @@ spec:
   strategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   selector:
-    matchLabels:
-      app: {{ .Chart.Name }}
-      release: {{ .Release.Name | quote }}
+    matchLabels: {{- include "opensearch-dashboards.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      labels:
-        app: {{ .Chart.Name }}
-        release: {{ .Release.Name | quote }}
-        {{- range $key, $value := .Values.labels }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
+      labels: {{- include "opensearch-dashboards.labels" . | nindent 8 }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/opensearch-dashboards/templates/service.yaml
+++ b/charts/opensearch-dashboards/templates/service.yaml
@@ -36,6 +36,4 @@ spec:
     protocol: TCP
     name: {{ .Values.service.httpPortName | default "http" }}
     targetPort: {{ .Values.service.port }}
-  selector:
-    app: {{ .Chart.Name }}
-    release: {{ .Release.Name | quote }}
+  selector: {{- include "opensearch-dashboards.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
### Description
Use the actual selectorLabels as generated.
 
### Issues Resolved
[487](https://github.com/opensearch-project/helm-charts/issues/487)
 
### Check List
- [ ] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
  Not sure if this can be a minor (2.15.0) or should be a major, as it includes a breaking change. When selector labels change, current resources need to be removed before they can be recreated.,
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
