### PR TITLE
Add user-defined labels option to ingress

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
+
+---
+## [2.17.2]
+### Added
+- - Allow user-defined labels on ingress resource
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
 ---
 ## [2.17.1]
 ### Added
@@ -365,7 +375,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.1...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.2...HEAD
+[2.17.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.1...opensearch-2.17.2
 [2.17.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.0...opensearch-2.17.1
 [2.17.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.16.1...opensearch-2.17.0
 [2.16.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.16.0...opensearch-2.16.1
@@ -402,3 +413,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [2.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.1.0...opensearch-2.2.0
 [2.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.0.1...opensearch-2.1.0
 [2.0.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.0.0...opensearch-2.0.1
+

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.17.1
+version: 2.17.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/ingress.yaml
+++ b/charts/opensearch/templates/ingress.yaml
@@ -16,6 +16,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
+    {{- with .Values.ingress.ingressLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -402,6 +402,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  ingressLabels: {}
   path: /
   hosts:
     - chart-example.local


### PR DESCRIPTION
### Description
Similar to #390 allow to add labels to Ingress in charts/opensearch
 
### Issues Resolved
Labels could be used in kube-prometheus-stack monitoring.coreos.com/v1 Probe objects as a selector.
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
