### PR TITLE
Add artifactshub metadata to get verified badge

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,17 @@
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+repositoryID: f66bda5e-0f6c-4beb-b9c0-8601266cb232
+owners:
+  - name: Idan Levi
+    email: idan@opster.com
+  - name: prudhvigodithi
+    email: pgodithi@amazon.com

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -11,7 +11,5 @@
 #
 repositoryID: f66bda5e-0f6c-4beb-b9c0-8601266cb232
 owners:
-  - name: Idan Levi
-    email: idan@opster.com
   - name: prudhvigodithi
     email: pgodithi@amazon.com


### PR DESCRIPTION
### Description
@prudhvigodithi this gives the official badge on opensearch charts
 
### Issues Resolved
- https://github.com/artifacthub/hub/issues/3533
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
