### PR TITLE
Fix `opensearch.yml` configMap Read-only file system error

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
+## [2.17.3]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Bug `opensearch.yml` configMap Read-only file system error.
+### Security
+---
 ## [2.17.2]
 ### Added
 - - Allow user-defined labels on ingress resource
@@ -375,7 +384,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.2...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.3...HEAD
+[2.17.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.2...opensearch-2.17.3
 [2.17.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.1...opensearch-2.17.2
 [2.17.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.0...opensearch-2.17.1
 [2.17.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.16.1...opensearch-2.17.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.17.2
+version: 2.17.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -156,6 +156,13 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriod }}
       volumes:
+      {{- if .Values.config }}
+      - name: config
+        configMap:
+          name: {{ template "opensearch.uname" . }}-config
+      - emptyDir: {}
+        name: config-emptydir
+      {{- end }}
       {{- range .Values.secretMounts }}
       - name: {{ .name | required "secretMount .name is required" }}
         secret:
@@ -163,11 +170,6 @@ spec:
           {{- if .defaultMode }}
           defaultMode: {{ .defaultMode }}
           {{- end }}
-      {{- end }}
-      {{- if .Values.config }}
-      - name: config
-        configMap:
-          name: {{ template "opensearch.uname" . }}-config
       {{- end }}
       {{- if and .Values.securityConfig.config.data .Values.securityConfig.config.securityConfigSecret }}
       {{ fail "Only one of .Values.securityConfig.config.data and .Values.securityConfig.config.securityConfigSecret may be defined. Please see the comment in values.yaml describing usage." }}
@@ -238,7 +240,7 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{ toYaml .Values.hostAliases | nindent 8 }}
       {{- end }}
-      {{- if or (.Values.extraInitContainers) (.Values.keystore) (.Values.persistence.enabled) (.Values.sysctlInit.enabled)  }}
+      {{- if or (.Values.extraInitContainers) (.Values.keystore) (.Values.persistence.enabled) (.Values.sysctlInit.enabled) (.Values.config)  }}
       initContainers:
 {{- if and .Values.persistence.enabled .Values.persistence.enableInitChown }}
       - name: fsgroup-volume
@@ -274,6 +276,27 @@ spec:
           privileged: true
         resources:
           {{- toYaml .Values.initResources | nindent 10 }}
+{{- end }}
+{{- if .Values.config }}
+      - name: configfile
+        image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        command:
+        - sh
+        - -c
+        - |
+          #!/usr/bin/env bash
+          cp -r /tmp/configfolder/*  /tmp/config/
+        resources:
+          {{- toYaml .Values.initResources | nindent 10 }}
+        volumeMounts:
+          - mountPath: /tmp/config/
+            name: config-emptydir
+        {{- range $path, $config := .Values.config }}
+          - name: config
+            mountPath: /tmp/configfolder/{{ $path }}
+            subPath: {{ $path }}
+        {{- end -}}
 {{- end }}
 {{- if .Values.keystore }}
       - name: keystore
@@ -470,7 +493,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- range $path, $config := .Values.config }}
-        - name: config
+        - name: config-emptydir
           mountPath: {{ $.Values.opensearchHome }}/config/{{ $path }}
           subPath: {{ $path }}
         {{- end -}}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -30,6 +30,7 @@ global:
 
 # Allows you to add any config files in {{ .Values.opensearchHome }}/config
 opensearchHome: /usr/share/opensearch
+
 # such as opensearch.yml and log4j2.properties
 config:
   # Values must be YAML literal style scalar / YAML multiline string.


### PR DESCRIPTION
### Description

Coming from an open PR https://github.com/opensearch-project/helm-charts/pull/504, that removes `opensearch.yml` due to configMap Read-only file system error (as starting 2.12.0 OpenSearch security plugin need RW access to `opensearch.yml` when passed `OPENSEARCH_INITIAL_ADMIN_PASSWORD`, for more details ref: https://github.com/opensearch-project/security/issues/3624).

This PR will have a fix to continue use the `.Values.config` and declare the `opensearch.yml` and does not throw configMap Read-only file system error.

With this the user can either use the default `opensearch.yml`  or pass the `opensearch.yml` via `.Values.config`. 
 
### Issues Resolved
https://github.com/opensearch-project/helm-charts/issues/224
part of: https://github.com/opensearch-project/security/issues/3624, https://github.com/opensearch-project/security/issues/3711
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
