### PR TITLE
520 add app protocol for http port

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.18.0]
 ### Added
+ - Add `service : spec.port[].appProtocol` value according to `Value.protocol` so it could be used with GKE Gateway Controller 
+### Breaking
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
+
+## [2.18.0]
+### Added
 ### Breaking
  - Requires an initial admin password to be setup starting from App Version OpenSearch 2.12.0. Refer this github issue: https://github.com/opensearch-project/security/issues/3622
  - Updated OpenSearch appVersion to 2.12.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.18.0
+version: 2.19.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/service.yaml
+++ b/charts/opensearch/templates/service.yaml
@@ -66,6 +66,7 @@ spec:
   ports:
   - name: {{ .Values.service.httpPortName | default "http" }}
     port: {{ .Values.httpPort }}
+    appProtocol: {{ upper .Values.protocol }}
   - name: {{ .Values.service.transportPortName | default "transport" }}
     port: {{ .Values.transportPort }}
   - name: {{ .Values.service.metricsPortName | default "metrics" }}


### PR DESCRIPTION
### Description
add `service : spec.port[].appProtocol` value according to `Value.protocol`
 
### Issues Resolved
This would fix #520 by adding appProtocol property to "http" port (default 9200)
 
### Check List
- [ ] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
