### PR TITLE
Parameterize service.protocol for opensearch-dashboards

### DIFF
--- a/charts/opensearch-dashboards/templates/service.yaml
+++ b/charts/opensearch-dashboards/templates/service.yaml
@@ -33,7 +33,7 @@ spec:
 {{- if .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}
-    protocol: TCP
+    protocol: {{ .Values.service.protocol | default "TCP" }}
     name: {{ .Values.service.httpPortName | default "http" }}
     targetPort: {{ .Values.service.port }}
   selector:

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -162,6 +162,7 @@ service:
   annotations: {}
   loadBalancerSourceRanges: []
   # 0.0.0.0/0
+  # protocol: HTTP
   httpPortName: http
 
 ingress:


### PR DESCRIPTION
### Description
This will allow users to specify the protocol for the service definition, which is currently hardcoded to TCP.
Allows for better integration e.g. with Istio.
 
### Issues Resolved
https://github.com/opensearch-project/helm-charts/issues/532
 
### Check List
- [ ] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
