### PR TITLE
feat: Add ServiceMonitor object to opensearch

### DIFF
--- a/charts/opensearch/templates/serviceMonitor.yaml
+++ b/charts/opensearch/templates/serviceMonitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "opensearch.uname" . }}-service-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opensearch.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "opensearch.labels" . | nindent 4 }}
+  endpoints:
+  - port: {{ .Values.metricsPort }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    path: {{ .Values.serviceMonitor.path }}
+{{- end }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -529,3 +529,9 @@ extraObjects: []
   #      selector:
   #        matchLabels:
   #          {{- include "opensearch.selectorLabels" . | nindent 6 }}
+
+
+serviceMonitor:
+  enabled: false
+  path: /metrics
+  interval: 10s


### PR DESCRIPTION
Signed-off-by: Shubham Gupta <iamshubhamgupta2001@gmail.com>

### Description
It would add a prometheus serviceMonitor resource.
 
### Issues Resolved
[List any issues this PR will resolve. You should likely open an issue if one does not already exist.]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
