### PR TITLE
Backport #545 maintainers to 1.x branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @bbarani @TheAlgo @DandyDeveloper @peterzhuamazon @prudhvigodithi @gaiksaya
+*  @TheAlgo @DandyDeveloper @peterzhuamazon @prudhvigodithi @gaiksaya

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,12 +1,18 @@
-## Maintainers
+## Overview
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
 
-| Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Barani Bikshandi | [bbarani](https://github.com/bbarani) | Amazon |
-| Peter Zhu | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon |
-| Sayali Gaikawad | [gaiksaya](https://github.com/gaiksaya) | Amazon |
-| Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon |
-| Dhiraj Kumar Jain | [TheAlgo](https://github.com/TheAlgo) | Amazon |
-| Aaron Layfield | [DandyDeveloper](https://github.com/DandyDeveloper) | Community |
+## Current Maintainers
 
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+| Maintainer        | GitHub ID                                           | Affiliation |
+| ----------------- | --------------------------------------------------- | ----------- |
+| Peter Zhu         | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon      |
+| Sayali Gaikawad   | [gaiksaya](https://github.com/gaiksaya)             | Amazon      |
+| Prudhvi Godithi   | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon      |
+| Dhiraj Kumar Jain | [TheAlgo](https://github.com/TheAlgo)               | Amazon      |
+| Aaron Layfield    | [DandyDeveloper](https://github.com/DandyDeveloper) | Community   |
+
+## Emeritus
+
+| Maintainer            | GitHub ID                                 | Affiliation |
+| --------------------- | ----------------------------------------- | ----------- |
+| Barani Bikshandi  | [bbarani](https://github.com/bbarani)               | Amazon      |

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -25,7 +25,6 @@ appVersion: "1.3.16"
 
 maintainers:
   - name: DandyDeveloper
-  - name: bbarani
   - name: gaiksaya
   - name: peterzhuamazon
   - name: prudhvigodithi

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -25,7 +25,6 @@ appVersion: "1.3.16"
 
 maintainers:
   - name: DandyDeveloper
-  - name: bbarani
   - name: gaiksaya
   - name: peterzhuamazon
   - name: prudhvigodithi


### PR DESCRIPTION
### Description
Backport #545 maintainers to 1.x branch
 
### Issues Resolved
Backport #545 maintainers to 1.x branch
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
