### PR TITLE
feat: Add initial version of data-prepper helm chart

### DIFF
--- a/charts/data-prepper/.helmignore
+++ b/charts/data-prepper/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/data-prepper/CHANGELOG.md
+++ b/charts/data-prepper/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Create initial version of data-prepper helm chart
+

--- a/charts/data-prepper/Chart.yaml
+++ b/charts/data-prepper/Chart.yaml
@@ -1,0 +1,50 @@
+apiVersion: v2
+name: data-prepper
+description: A Helm chart for Data Prepper
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "2.8.0"
+
+maintainers:
+  - name: gaiksaya
+    url: https://github.com/gaiksaya
+  - name: peterzhuamazon
+    url: https://github.com/peterzhuamazon
+  - name: prudhvigodithi
+    url: https://github.com/prudhvigodithi
+  - name: sergk
+    url: https://github.com/sergk
+  - name: TheAlgo
+    url: https://github.com/TheAlgo
+
+home: https://opensearch.org/docs/latest/data-prepper/
+sources:
+  - https://github.com/opensearch-project/data-prepper
+  - https://github.com/opensearch-project/helm-charts
+
+annotations:
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Data Prepper Documentation
+      url: https://opensearch.org/docs/latest/data-prepper/
+    - name: OpenSearch Project
+      url: https://opensearch.org

--- a/charts/data-prepper/README.md
+++ b/charts/data-prepper/README.md
@@ -1,0 +1,125 @@
+# Data Prepper Helm Chart
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
+
+A Helm chart for Data Prepper
+
+**Homepage:** <https://opensearch.org/docs/latest/data-prepper/>
+
+Data Prepper is an essential component of the OpenSearch project, designed for high-volume data transformation and ingestion into OpenSearch. This Helm chart simplifies deploying Data Prepper on Kubernetes environments, ensuring you can easily set up your data processing pipelines.
+
+## Requirements
+
+Before installing the Data Prepper Helm chart, ensure your environment meets the following requirements:
+
+* Kubernetes >= 1.14
+* Helm >= 2.17.0
+* We recommend having at least 4 GiB of memory available for this deployment. A minimum of 2 GiB may suffice, but less than that could lead to deployment failures.
+
+## Installation
+
+To install the Data Prepper Helm chart, follow these steps:
+
+* Add the OpenSearch Helm repository if you haven't already:
+
+```bash
+helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+helm repo update
+```
+
+* Install the Data Prepper chart with:
+
+```bash
+helm install my-data-prepper-release opensearch/data-prepper
+```
+
+Replace my-data-prepper-release with your desired release name.
+
+## Configuration
+
+The Data Prepper Helm chart comes with a variety of configuration options to tailor the deployment to your needs.
+The default values are specified in the [values.yaml](values.yaml) file. You can override these values by providing your own values.yaml file during installation or by specifying configuration options with --set flags.
+
+For a detailed list of configuration options, refer to the values.yaml file or the [Data Prepper documentation](https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/configuring-data-prepper/).
+
+## Uninstalling the Chart
+
+To uninstall/delete the my-data-prepper deployment:
+
+```bash
+helm delete my-data-prepper
+```
+
+This command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Contributing
+
+We welcome contributions! Please read our [CONTRIBUTING.md](../../CONTRIBUTING.md) for details on how to submit contributions to this project.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| gaiksaya |  | <https://github.com/gaiksaya> |
+| peterzhuamazon |  | <https://github.com/peterzhuamazon> |
+| prudhvigodithi |  | <https://github.com/prudhvigodithi> |
+| sergk |  | <https://github.com/sergk> |
+| TheAlgo |  | <https://github.com/TheAlgo> |
+
+## Source Code
+
+* <https://github.com/opensearch-project/data-prepper>
+* <https://github.com/opensearch-project/helm-charts>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| config | object | `{"data-prepper-config.yaml":"ssl: false\n# circuit_breakers:\n#   heap:\n#     usage: 2gb\n#     reset: 30s\n#     check_interval: 5s\n","log4j2-rolling.properties":"#\n# Copyright OpenSearch Contributors\n# SPDX-License-Identifier: Apache-2.0\n#\n\nstatus = error\ndest = err\nname = PropertiesConfig\n\nproperty.filename = log/data-prepper/data-prepper.log\n\nappender.console.type = Console\nappender.console.name = STDOUT\nappender.console.layout.type = PatternLayout\nappender.console.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n\n\nappender.rolling.type = RollingFile\nappender.rolling.name = RollingFile\nappender.rolling.fileName = ${filename}\nappender.rolling.filePattern = logs/data-prepper.log.%d{MM-dd-yy-HH}-%i.gz\nappender.rolling.layout.type = PatternLayout\nappender.rolling.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n\nappender.rolling.policies.type = Policies\nappender.rolling.policies.time.type = TimeBasedTriggeringPolicy\nappender.rolling.policies.time.interval = 1\nappender.rolling.policies.time.modulate = true\nappender.rolling.policies.size.type = SizeBasedTriggeringPolicy\nappender.rolling.policies.size.size=100MB\nappender.rolling.strategy.type = DefaultRolloverStrategy\nappender.rolling.strategy.max = 168\n\nrootLogger.level = warn\nrootLogger.appenderRef.stdout.ref = STDOUT\nrootLogger.appenderRef.file.ref = RollingFile\n\nlogger.pipeline.name = org.opensearch.dataprepper.pipeline\nlogger.pipeline.level = info\n\nlogger.parser.name = org.opensearch.dataprepper.parser\nlogger.parser.level = info\n\nlogger.plugins.name = org.opensearch.dataprepper.plugins\nlogger.plugins.level = info\n"}` | Data Prepper configuration |
+| config."data-prepper-config.yaml" | string | `"ssl: false\n# circuit_breakers:\n#   heap:\n#     usage: 2gb\n#     reset: 30s\n#     check_interval: 5s\n"` | Main Data Prepper configuration file content |
+| config."log4j2-rolling.properties" | string | `"#\n# Copyright OpenSearch Contributors\n# SPDX-License-Identifier: Apache-2.0\n#\n\nstatus = error\ndest = err\nname = PropertiesConfig\n\nproperty.filename = log/data-prepper/data-prepper.log\n\nappender.console.type = Console\nappender.console.name = STDOUT\nappender.console.layout.type = PatternLayout\nappender.console.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n\n\nappender.rolling.type = RollingFile\nappender.rolling.name = RollingFile\nappender.rolling.fileName = ${filename}\nappender.rolling.filePattern = logs/data-prepper.log.%d{MM-dd-yy-HH}-%i.gz\nappender.rolling.layout.type = PatternLayout\nappender.rolling.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n\nappender.rolling.policies.type = Policies\nappender.rolling.policies.time.type = TimeBasedTriggeringPolicy\nappender.rolling.policies.time.interval = 1\nappender.rolling.policies.time.modulate = true\nappender.rolling.policies.size.type = SizeBasedTriggeringPolicy\nappender.rolling.policies.size.size=100MB\nappender.rolling.strategy.type = DefaultRolloverStrategy\nappender.rolling.strategy.max = 168\n\nrootLogger.level = warn\nrootLogger.appenderRef.stdout.ref = STDOUT\nrootLogger.appenderRef.file.ref = RollingFile\n\nlogger.pipeline.name = org.opensearch.dataprepper.pipeline\nlogger.pipeline.level = info\n\nlogger.parser.name = org.opensearch.dataprepper.parser\nlogger.parser.level = info\n\nlogger.plugins.name = org.opensearch.dataprepper.plugins\nlogger.plugins.level = info\n"` | Log4j2 configuration for Data Prepper logging |
+| extraEnvs | list | `[]` | Extra environment variables to pass to the Data Prepper container |
+| fullnameOverride | string | `""` | Override the default fullname for the deployment |
+| image.pullPolicy | string | `"IfNotPresent"` | The image tag to pull. Default: IfNotPresent |
+| image.repository | string | `"opensearchproject/data-prepper"` | The image repository from which to pull the Data Prepper image |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | List of imagePullSecrets to use if the Docker image is stored in a private registry |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.tls | list | `[]` |  |
+| nameOverride | string | `""` | Override the default name for the deployment |
+| nodeSelector | object | `{}` |  |
+| pipelineConfig | object | `{"config":{"simple-sample-pipeline":{"buffer":{"bounded_blocking":{"batch_size":256,"buffer_size":1024}},"delay":5000,"processor":[{"string_converter":{"upper_case":true}}],"sink":[{"stdout":null}],"source":{"random":null},"workers":2}},"enabled":true,"existingSecret":""}` | Pipeline configuration |
+| pipelineConfig.existingSecret | string | `""` | The name of the existing secret containing the pipeline configuration. If enabled is false existingSecret is used. The existingSecret must have a key named `pipelines.yaml`. |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| ports | list | `[{"name":"http-source","port":2021},{"name":"otel-traces","port":21890},{"name":"otel-metrics","port":21891},{"name":"otel-logs","port":21892}]` | Data Prepper ports |
+| ports[0] | object | `{"name":"http-source","port":2021}` | The port that the source is running on. Default value is 2021. Valid options are between 0 and 65535. https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/http-source/ |
+| ports[1] | object | `{"name":"otel-traces","port":21890}` | The port that the otel_trace_source source runs on. Default value is 21890. https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-trace-source/ |
+| ports[2] | object | `{"name":"otel-metrics","port":21891}` | The port that the OpenTelemtry metrics source runs on. Default value is 21891. https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/ |
+| ports[3] | object | `{"name":"otel-logs","port":21892}` | Represents the port that the otel_logs_source source is running on. Default value is 21892. https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-logs-source/ |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| tolerations | list | `[]` |  |
+| volumeMounts | list | `[]` |  |
+| volumes | list | `[]` |  |
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE.txt](../../LICENSE.txt) file for details.

--- a/charts/data-prepper/README.md.gotmpl
+++ b/charts/data-prepper/README.md.gotmpl
@@ -1,0 +1,71 @@
+# Data Prepper Helm Chart
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+Data Prepper is an essential component of the OpenSearch project, designed for high-volume data transformation and ingestion into OpenSearch. This Helm chart simplifies deploying Data Prepper on Kubernetes environments, ensuring you can easily set up your data processing pipelines.
+
+## Requirements
+
+Before installing the Data Prepper Helm chart, ensure your environment meets the following requirements:
+
+* Kubernetes >= 1.14
+* Helm >= 2.17.0
+* We recommend having at least 4 GiB of memory available for this deployment. A minimum of 2 GiB may suffice, but less than that could lead to deployment failures.
+
+## Installation
+
+To install the Data Prepper Helm chart, follow these steps:
+
+* Add the OpenSearch Helm repository if you haven't already:
+
+```bash
+helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+helm repo update
+```
+
+* Install the Data Prepper chart with:
+
+```bash
+helm install my-data-prepper-release opensearch/data-prepper
+```
+
+Replace my-data-prepper-release with your desired release name.
+
+## Configuration
+
+The Data Prepper Helm chart comes with a variety of configuration options to tailor the deployment to your needs.
+The default values are specified in the [values.yaml](values.yaml) file. You can override these values by providing your own values.yaml file during installation or by specifying configuration options with --set flags.
+
+For a detailed list of configuration options, refer to the values.yaml file or the [Data Prepper documentation](https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/configuring-data-prepper/).
+
+## Uninstalling the Chart
+
+To uninstall/delete the my-data-prepper deployment:
+
+```bash
+helm delete my-data-prepper
+```
+
+This command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Contributing
+
+We welcome contributions! Please read our [CONTRIBUTING.md](../../CONTRIBUTING.md) for details on how to submit contributions to this project.
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE.txt](../../LICENSE.txt) file for details.

--- a/charts/data-prepper/templates/NOTES.txt
+++ b/charts/data-prepper/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "data-prepper.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "data-prepper.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "data-prepper.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "data-prepper.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/data-prepper/templates/_helpers.tpl
+++ b/charts/data-prepper/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "data-prepper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "data-prepper.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "data-prepper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "data-prepper.labels" -}}
+helm.sh/chart: {{ include "data-prepper.chart" . }}
+{{ include "data-prepper.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "data-prepper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "data-prepper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "data-prepper.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "data-prepper.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/data-prepper/templates/configmap.yaml
+++ b/charts/data-prepper/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "data-prepper.fullname" . }}-config
+  labels:
+    {{- include "data-prepper.labels" . | nindent 4 }}
+data:
+{{- range $configName, $configYaml := .Values.config }}
+  {{ $configName }}: |
+  {{- if eq (kindOf $configYaml) "map" }}
+    {{- tpl (toYaml $configYaml) $ | nindent 4 }}
+  {{- else }}
+    {{- tpl $configYaml $ | nindent 4 -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/data-prepper/templates/deployment.yaml
+++ b/charts/data-prepper/templates/deployment.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "data-prepper.fullname" . }}
+  labels:
+    {{- include "data-prepper.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "data-prepper.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.config }}
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
+      {{- end }}
+      {{- if .Values.pipelineConfig.enabled }}
+        checksum/pipelineconfig: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum | trunc 63 }}
+      {{- end }}
+      labels:
+        {{- include "data-prepper.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "data-prepper.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          env:
+            {{- with .Values.extraEnvs }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          {{- range .Values.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+              protocol: TCP
+          {{- end }}
+            - name: server
+              containerPort: {{ (.Values.config).serverPort | default 4900 }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /list
+              port: server
+              {{- if not ( empty (.Values.config).ssl ) }}
+              scheme: HTTPS
+              {{- end }}
+            periodSeconds: 10
+            initialDelaySeconds: 2
+            failureThreshold: 2
+          readinessProbe:
+            httpGet:
+              path: /list
+              port: server
+              {{- if not ( empty (.Values.config).ssl ) }}
+              scheme: HTTPS
+              {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data-prepper-config
+              mountPath: /usr/share/data-prepper/config
+              readOnly: true
+            - name: data-prepper-pipelines
+              mountPath: /usr/share/data-prepper/pipelines
+              readOnly: true
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: data-prepper-config
+          configMap:
+            name: {{ include "data-prepper.fullname" . }}-config
+        - name: data-prepper-pipelines
+          secret:
+          {{- if .Values.pipelineConfig.enabled }}
+            secretName: {{ include "data-prepper.fullname" . }}-pipeline
+          {{- else }}
+            secretName: {{ required "A valid .Values.pipelineConfig.existingSecret entry required!" .Values.pipelineConfig.existingSecret }}
+          {{- end }}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/data-prepper/templates/hpa.yaml
+++ b/charts/data-prepper/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "data-prepper.fullname" . }}
+  labels:
+    {{- include "data-prepper.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "data-prepper.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/data-prepper/templates/ingress.yaml
+++ b/charts/data-prepper/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "data-prepper.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "data-prepper.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/data-prepper/templates/secret.yaml
+++ b/charts/data-prepper/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.pipelineConfig.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "data-prepper.fullname" . }}-pipeline
+  labels:
+    {{- include "data-prepper.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  pipelines.yaml: |
+    {{- toYaml .Values.pipelineConfig.config | nindent 4 }}
+{{- end }}

--- a/charts/data-prepper/templates/service.yaml
+++ b/charts/data-prepper/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "data-prepper.fullname" . }}
+  labels:
+    {{- include "data-prepper.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  {{- range .Values.ports }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .port }}
+      protocol: TCP
+  {{- end }}
+  selector:
+    {{- include "data-prepper.selectorLabels" . | nindent 4 }}

--- a/charts/data-prepper/templates/serviceaccount.yaml
+++ b/charts/data-prepper/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "data-prepper.serviceAccountName" . }}
+  labels:
+    {{- include "data-prepper.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/data-prepper/values.yaml
+++ b/charts/data-prepper/values.yaml
@@ -1,0 +1,354 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for data-prepper.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  # -- The image repository from which to pull the Data Prepper image
+  repository: opensearchproject/data-prepper
+  # -- The image tag to pull. Default: IfNotPresent
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# -- List of imagePullSecrets to use if the Docker image is stored in a private registry
+imagePullSecrets: []
+# -- Override the default name for the deployment
+nameOverride: ""
+# -- Override the default fullname for the deployment
+fullnameOverride: ""
+
+# -- Extra environment variables to pass to the Data Prepper container
+extraEnvs: []
+  # - name: "JAVA_OPTS"
+  #   value: "-Dlog4j2.debug=true"
+
+# Check https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/configuring-data-prepper/
+# for more information on the configuration options
+# -- Data Prepper configuration
+config:
+  # -- Main Data Prepper configuration file content
+  data-prepper-config.yaml: |
+    ssl: false
+    # circuit_breakers:
+    #   heap:
+    #     usage: 2gb
+    #     reset: 30s
+    #     check_interval: 5s
+
+  # -- Log4j2 configuration for Data Prepper logging
+  log4j2-rolling.properties: |
+    #
+    # Copyright OpenSearch Contributors
+    # SPDX-License-Identifier: Apache-2.0
+    #
+
+    status = error
+    dest = err
+    name = PropertiesConfig
+
+    property.filename = log/data-prepper/data-prepper.log
+
+    appender.console.type = Console
+    appender.console.name = STDOUT
+    appender.console.layout.type = PatternLayout
+    appender.console.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n
+
+    appender.rolling.type = RollingFile
+    appender.rolling.name = RollingFile
+    appender.rolling.fileName = ${filename}
+    appender.rolling.filePattern = logs/data-prepper.log.%d{MM-dd-yy-HH}-%i.gz
+    appender.rolling.layout.type = PatternLayout
+    appender.rolling.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n
+    appender.rolling.policies.type = Policies
+    appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+    appender.rolling.policies.time.interval = 1
+    appender.rolling.policies.time.modulate = true
+    appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+    appender.rolling.policies.size.size=100MB
+    appender.rolling.strategy.type = DefaultRolloverStrategy
+    appender.rolling.strategy.max = 168
+
+    rootLogger.level = warn
+    rootLogger.appenderRef.stdout.ref = STDOUT
+    rootLogger.appenderRef.file.ref = RollingFile
+
+    logger.pipeline.name = org.opensearch.dataprepper.pipeline
+    logger.pipeline.level = info
+
+    logger.parser.name = org.opensearch.dataprepper.parser
+    logger.parser.level = info
+
+    logger.plugins.name = org.opensearch.dataprepper.plugins
+    logger.plugins.level = info
+
+# For OpenSearch Data Prepper is crucial for defining the behavior and structure of your data processing pipelines.
+# Each pipeline is defined with a unique name and can include `source`, `processor`, and `sink` components to ingest,
+# process, and output data respectively. This flexible configuration allows for the creation of complex data processing
+# flows, including the routing of data between pipelines.
+# For detailed information on the available options and to get the most up-to-date guidance on configuring `pipeline.yaml`,
+# please consult the [OpenSearch Documentation on Pipelines](https://opensearch.org/docs/2.4/data-prepper/pipelines/pipelines/).
+# This resource provides comprehensive examples and explanations of each component, ensuring you can tailor your Data Prepper
+# deployment to meet your specific data processing needs.
+
+# -- Pipeline configuration
+pipelineConfig:
+  # If enabled, a secret containing the pipeline configuration will be created based on the 'config' section below.
+  enabled: true
+  # -- The name of the existing secret containing the pipeline configuration.
+  # If enabled is false existingSecret is used. The existingSecret must have a key named `pipelines.yaml`.
+  existingSecret: ""
+  # The configuration of the pipeline see https://opensearch.org/docs/2.4/data-prepper/pipelines/pipelines/
+  config:
+    ## Simple Example
+    simple-sample-pipeline:
+      workers: 2      # the number of workers
+      delay: 5000     # in milliseconds, how long workers wait between read attempts
+      source:
+        random:
+      buffer:
+        bounded_blocking:
+          buffer_size: 1024     # max number of records the buffer accepts
+          batch_size: 256       # max number of records the buffer drains after each read
+      processor:
+        - string_converter:
+            upper_case: true
+      sink:
+        - stdout:
+
+    ## More Complex example
+    # otel-logs-pipeline:
+    #   workers: 5
+    #   delay: 10
+    #   source:
+    #     otel_logs_source:
+    #       ssl: false
+    #   buffer:
+    #     bounded_blocking:
+    #   sink:
+    #     - opensearch:
+    #         hosts: ["https://opensearch-cluster-master:9200"]
+    #         username: "admin"
+    #         password: "admin"
+    #         insecure: true
+    #         index_type: custom
+    #         index: events-%{yyyy.MM.dd}
+    #         #max_retries: 20
+    #         bulk_size: 4
+    # otel-trace-pipeline:
+    #   # workers is the number of threads processing data in each pipeline.
+    #   # We recommend same value for all pipelines.
+    #   # default value is 1, set a value based on the machine you are running Data Prepper
+    #   workers: 8
+    #   # delay in milliseconds is how often the worker threads should process data.
+    #   # Recommend not to change this config as we want the otel-trace-pipeline to process as quick as possible
+    #   # default value is 3_000 ms
+    #   delay: "100"
+    #   source:
+    #     otel_trace_source:
+    #       ssl: false # Change this to enable encryption in transit
+    #   buffer:
+    #     bounded_blocking:
+    #       # buffer_size is the number of ExportTraceRequest from otel-collector the data prepper should hold in memeory.
+    #       # We recommend to keep the same buffer_size for all pipelines.
+    #       # Make sure you configure sufficient heap
+    #       # default value is 12800
+    #       buffer_size: 25600
+    #       # This is the maximum number of request each worker thread will process within the delay.
+    #       # Default is 200.
+    #       # Make sure buffer_size >= workers * batch_size
+    #       batch_size: 400
+    #   sink:
+    #     - pipeline:
+    #         name: "raw-traces-pipeline"
+    #     - pipeline:
+    #         name: "otel-service-map-pipeline"
+    # raw-traces-pipeline:
+    #   workers: 5
+    #   delay: 3000
+    #   source:
+    #     pipeline:
+    #       name: "otel-trace-pipeline"
+    #   buffer:
+    #     bounded_blocking:
+    #       buffer_size: 25600 # max number of records the buffer accepts
+    #       batch_size: 400 # max number of records the buffer drains after each read
+    #   processor:
+    #     - otel_traces:
+    #     - otel_trace_group:
+    #         hosts: [ "https://opensearch-cluster-master:9200" ]
+    #         insecure: true
+    #         username: "admin"
+    #         password: "admin"
+    #   sink:
+    #     - opensearch:
+    #         hosts: ["https://opensearch-cluster-master:9200"]
+    #         username: "admin"
+    #         password: "admin"
+    #         insecure: true
+    #         index_type: trace-analytics-raw
+    # otel-service-map-pipeline:
+    #   workers: 5
+    #   delay: 3000
+    #   source:
+    #     pipeline:
+    #       name: "otel-trace-pipeline"
+    #   processor:
+    #     - service_map:
+    #         # The window duration is the maximum length of time the data prepper stores the most recent trace data to evaluvate service-map relationships.
+    #         # The default is 3 minutes, this means we can detect relationships between services from spans reported in last 3 minutes.
+    #         # Set higher value if your applications have higher latency.
+    #         window_duration: 180
+    #   buffer:
+    #       bounded_blocking:
+    #         # buffer_size is the number of ExportTraceRequest from otel-collector the data prepper should hold in memeory.
+    #         # We recommend to keep the same buffer_size for all pipelines.
+    #         # Make sure you configure sufficient heap
+    #         # default value is 12800
+    #         buffer_size: 25600
+    #         # This is the maximum number of request each worker thread will process within the delay.
+    #         # Default is 200.
+    #         # Make sure buffer_size >= workers * batch_size
+    #         batch_size: 400
+    #   sink:
+    #     - opensearch:
+    #         hosts: ["https://opensearch-cluster-master:9200"]
+    #         username: "admin"
+    #         password: "admin"
+    #         insecure: true
+    #         index_type: trace-analytics-service-map
+    #         #index: otel-v1-apm-span-%{yyyy.MM.dd}
+    #         #max_retries: 20
+    #         bulk_size: 4
+    # otel-metrics-pipeline:
+    #   workers: 8
+    #   delay: 3000
+    #   source:
+    #     otel_metrics_source:
+    #       health_check_service: true
+    #       ssl: false
+    #   buffer:
+    #     bounded_blocking:
+    #       buffer_size: 1024 # max number of records the buffer accepts
+    #       batch_size: 1024 # max number of records the buffer drains after each read
+    #   processor:
+    #     - otel_metrics:
+    #         calculate_histogram_buckets: true
+    #         calculate_exponential_histogram_buckets: true
+    #         exponential_histogram_max_allowed_scale: 10
+    #         flatten_attributes: false
+    #   sink:
+    #     - opensearch:
+    #         hosts: ["https://opensearch-cluster-master:9200"]
+    #         username: "admin"
+    #         password: "admin"
+    #         insecure: true
+    #         index_type: custom
+    #         index: metrics-%{yyyy.MM.dd}
+    #         #max_retries: 20
+    #         bulk_size: 4
+
+# -- Data Prepper ports
+ports:
+  # -- The port that the source is running on. Default value is 2021. Valid options are between 0 and 65535.
+  # https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/http-source/
+  - name: http-source
+    port: 2021
+  # -- The port that the otel_trace_source source runs on. Default value is 21890.
+  # https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-trace-source/
+  - name: otel-traces
+    port: 21890
+  # -- The port that the OpenTelemtry metrics source runs on. Default value is 21891.
+  # https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/
+  - name: otel-metrics
+    port: 21891
+  # -- Represents the port that the otel_logs_source source is running on. Default value is 21892.
+  # https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-logs-source/
+  - name: otel-logs
+    port: 21892
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
### Description
Let's start with the initial version of the data-prepper.
We can extend it later with more examples of configuration
 
### Issues Resolved
Related issue: #45
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
