### PR TITLE
fix: rename storageClass to storageClassName based in docs and comments

### DIFF
--- a/charts/opensearch/ci/ci-ingress-class-name-values.yaml
+++ b/charts/opensearch/ci/ci-ingress-class-name-values.yaml
@@ -195,13 +195,13 @@ persistence:
     # Add default labels for the volumeClaimTemplate of the StatefulSet
     enabled: false
   # OpenSearch Persistent Volume Storage Class
-  # If defined, storageClassName: <storageClass>
+  # If defined, storageClassName: <storageClassName>
   # If set to "-", storageClassName: "", which disables dynamic provisioning
   # If undefined (the default) or set to null, no storageClassName spec is
   #   set, choosing the default provisioner.  (gp2 on AWS, standard on
   #   GKE, AWS & OpenStack)
   #
-  # storageClass: "-"
+  # storageClassName: "-"
   accessModes:
     - ReadWriteOnce
   size: 8Gi

--- a/charts/opensearch/ci/ci-rbac-enabled-values.yaml
+++ b/charts/opensearch/ci/ci-rbac-enabled-values.yaml
@@ -195,13 +195,13 @@ persistence:
     # Add default labels for the volumeClaimTemplate of the StatefulSet
     enabled: false
   # OpenSearch Persistent Volume Storage Class
-  # If defined, storageClassName: <storageClass>
+  # If defined, storageClassName: <storageClassName>
   # If set to "-", storageClassName: "", which disables dynamic provisioning
   # If undefined (the default) or set to null, no storageClassName spec is
   #   set, choosing the default provisioner.  (gp2 on AWS, standard on
   #   GKE, AWS & OpenStack)
   #
-  # storageClass: "-"
+  # storageClassName: "-"
   accessModes:
     - ReadWriteOnce
   size: 8Gi

--- a/charts/opensearch/ci/ci-values.yaml
+++ b/charts/opensearch/ci/ci-values.yaml
@@ -196,13 +196,13 @@ persistence:
     # Add default labels for the volumeClaimTemplate of the StatefulSet
     enabled: false
   # OpenSearch Persistent Volume Storage Class
-  # If defined, storageClassName: <storageClass>
+  # If defined, storageClassName: <storageClassName>
   # If set to "-", storageClassName: "", which disables dynamic provisioning
   # If undefined (the default) or set to null, no storageClassName spec is
   #   set, choosing the default provisioner.  (gp2 on AWS, standard on
   #   GKE, AWS & OpenStack)
   #
-  # storageClass: "-"
+  # storageClassName: "-"
   accessModes:
     - ReadWriteOnce
   size: 8Gi

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -43,11 +43,11 @@ spec:
       resources:
         requests:
           storage: {{ .Values.persistence.size | quote }}
-    {{- if .Values.persistence.storageClass }}
-    {{- if (eq "-" .Values.persistence.storageClass) }}
+    {{- if .Values.persistence.storageClassName }}
+    {{- if (eq "-" .Values.persistence.storageClassName) }}
       storageClassName: ""
     {{- else }}
-      storageClassName: "{{ .Values.persistence.storageClass }}"
+      storageClassName: "{{ .Values.persistence.storageClassName }}"
     {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -206,13 +206,13 @@ persistence:
     # Add default labels for the volumeClaimTemplate of the StatefulSet
     enabled: false
   # OpenSearch Persistent Volume Storage Class
-  # If defined, storageClassName: <storageClass>
+  # If defined, storageClassName: <storageClassName>
   # If set to "-", storageClassName: "", which disables dynamic provisioning
   # If undefined (the default) or set to null, no storageClassName spec is
   #   set, choosing the default provisioner.  (gp2 on AWS, standard on
   #   GKE, AWS & OpenStack)
   #
-  # storageClass: "-"
+  # storageClassName: "-"
   accessModes:
     - ReadWriteOnce
   size: 8Gi


### PR DESCRIPTION
### Description
In the [values.yaml] and [README.md], it mentions defining `storageClassName` to use a custom storageClassName. However, the variable in [statefulset.yaml] uses `storageClass` instead. This pull request changes `storageClass` to `storageClassName` to ensure consistency and proper functionality.
 
### Issues Resolved
- No specific issue number, but this change addresses the inconsistency between the documentation and the [statefulset.yaml] file regarding the `storageClassName`.

### Check List
- [* ] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


[values.yaml]:https://github.com/opensearch-project/helm-charts/blob/main/charts/opensearch/values.yaml
[README.md]:https://github.com/opensearch-project/helm-charts/blob/main/charts/opensearch/README.md
[statefulset.yaml]:https://github.com/opensearch-project/helm-charts/blob/main/charts/opensearch/templates/statefulset.yaml