### PR TITLE
Updated charts to follow the OpenSearch Project's inclusive language standards

### DIFF
--- a/charts/data-prepper/CHANGELOG.md
+++ b/charts/data-prepper/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0]
+### Changed
+- Updated OpenSearch language to follow the OpenSearch Project's inclusive language standards
+
 ## [0.2.0]
 ### Added
 - Added configurable `global.dockerRegistry`
@@ -11,4 +15,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0]
 ### Added
 - Create initial version of data-prepper helm chart
-

--- a/charts/data-prepper/Chart.yaml
+++ b/charts/data-prepper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-prepper/values.yaml
+++ b/charts/data-prepper/values.yaml
@@ -135,7 +135,7 @@ pipelineConfig:
     #     bounded_blocking:
     #   sink:
     #     - opensearch:
-    #         hosts: ["https://opensearch-cluster-master:9200"]
+    #         hosts: ["https://opensearch-cluster-manager:9200"]
     #         username: "admin"
     #         password: "admin"
     #         insecure: true
@@ -184,13 +184,13 @@ pipelineConfig:
     #   processor:
     #     - otel_traces:
     #     - otel_trace_group:
-    #         hosts: [ "https://opensearch-cluster-master:9200" ]
+    #         hosts: [ "https://opensearch-cluster-manager:9200" ]
     #         insecure: true
     #         username: "admin"
     #         password: "admin"
     #   sink:
     #     - opensearch:
-    #         hosts: ["https://opensearch-cluster-master:9200"]
+    #         hosts: ["https://opensearch-cluster-manager:9200"]
     #         username: "admin"
     #         password: "admin"
     #         insecure: true
@@ -220,7 +220,7 @@ pipelineConfig:
     #         batch_size: 400
     #   sink:
     #     - opensearch:
-    #         hosts: ["https://opensearch-cluster-master:9200"]
+    #         hosts: ["https://opensearch-cluster-manager:9200"]
     #         username: "admin"
     #         password: "admin"
     #         insecure: true
@@ -247,7 +247,7 @@ pipelineConfig:
     #         flatten_attributes: false
     #   sink:
     #     - opensearch:
-    #         hosts: ["https://opensearch-cluster-master:9200"]
+    #         hosts: ["https://opensearch-cluster-manager:9200"]
     #         username: "admin"
     #         password: "admin"
     #         insecure: true

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.26.0]
+### Added
+### Changed
+- Updated OpenSearch language to follow the OpenSearch Project's inclusive language standards
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [2.25.0]
 ### Added
 - Updated OpenSearch Dashboards appVersion to 2.18.0
@@ -430,7 +439,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.25.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.26.0...HEAD
+[2.26.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.25.0...opensearch-dashboards-2.26.0
 [2.25.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.24.1...opensearch-dashboards-2.25.0
 [2.24.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.24.0...opensearch-dashboards-2.24.1
 [2.24.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.23.0...opensearch-dashboards-2.24.0

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.25.0
+version: 2.26.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -5,7 +5,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-opensearchHosts: "https://opensearch-cluster-master:9200"
+opensearchHosts: "https://opensearch-cluster-manager:9200"
 replicaCount: 1
 
 image:

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.29.0]
+### Added
+### Changed
+- Updated OpenSearch language to follow the OpenSearch Project's inclusive language standards
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [2.28.0]
 ### Added
 ### Changed
@@ -539,7 +548,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.28.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.29.0...HEAD
+[2.29.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.28.0...opensearch-2.29.0
 [2.28.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.27.1...opensearch-2.28.0
 [2.27.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.27.0...opensearch-2.27.1
 [2.27.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.1...opensearch-2.27.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.28.0
+version: 2.29.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/README.md
+++ b/charts/opensearch/README.md
@@ -22,7 +22,7 @@ Once you've added this Helm repository as per the repository-level [README](../.
  helm install my-release opensearch/opensearch
  ```
 
-The command deploys OpenSearch with its associated components (data statefulsets, masters, clients) on the Kubernetes cluster in the default configuration.
+The command deploys OpenSearch with its associated components (data statefulsets, cluster managers, clients) on the Kubernetes cluster in the default configuration.
 
 **NOTE:** If using Helm 2 then you'll need to add the [`--name`](https://v2.helm.sh/docs/helm/#options-21) command line argument. If unspecified, Helm 2 will autogenerate a name for you.
 
@@ -65,14 +65,14 @@ helm uninstall my-release
 | `initResources` | Allows you to set the [resources][] for the `initContainer` in the StatefulSet | `{}` |
 | `keystore` | Allows you map Kubernetes secrets into the keystore. | `[]` |
 | `labels` | Configurable [labels][] applied to all OpenSearch pods | `{}` |
-| `masterService` | The service name used to connect to the masters. You only need to set this if your master `nodeGroup` is set to something other than `master` | `""` |
+| `clusterManagerService` | The service name used to connect to the cluster managers. You only need to set this if your cluster manager `nodeGroup` is set to something other than `manager` | `""` |
 | `maxUnavailable` | The [maxUnavailable][] value for the pod disruption budget. By default this will prevent Kubernetes from having more than 1 unhealthy pod in the node group | `1` |
 | `metricsPort` | The metrics port (for Performance Analyzer) that Kubernetes will use for the service. | `9600` |
 | `nameOverride` | Overrides the `clusterName` when used in the naming of resources | `""` |
 | `networkHost` | Value for the `network.host OpenSearch setting` | `0.0.0.0` |
 | `networkPolicy.create` | Enable network policy creation for OpenSearch | `false` |
 | `nodeAffinity` | Value for the [node affinity settings][] | `{}` |
-| `nodeGroup` | This is the name that will be used for each group of nodes in the cluster. The name will be `clusterName-nodeGroup-X` , `nameOverride-nodeGroup-X` if a `nameOverride` is specified, and `fullnameOverride-X` if a `fullnameOverride` is specified | `master` |
+| `nodeGroup` | This is the name that will be used for each group of nodes in the cluster. The name will be `clusterName-nodeGroup-X` , `nameOverride-nodeGroup-X` if a `nameOverride` is specified, and `fullnameOverride-X` if a `fullnameOverride` is specified | `manager` |
 | `nodeSelector` | Configurable [nodeSelector][] so that you can target specific nodes for your OpenSearch cluster | `{}` |
 | `persistence` | Enables a persistent volume for OpenSearch data. | see [values.yaml][] |
 | `persistence.enableInitChown` | Disable the `fsgroup-volume` initContainer that will update permissions on the persistent disk. | `true` |

--- a/charts/opensearch/ci/ci-ingress-class-name-values.yaml
+++ b/charts/opensearch/ci/ci-ingress-class-name-values.yaml
@@ -1,15 +1,15 @@
 ---
 clusterName: "opensearch-cluster"
-nodeGroup: "master"
+nodeGroup: "manager"
 
-# The service that non master groups will try to connect to when joining the cluster
-# This should be set to clusterName + "-" + nodeGroup for your master group
-masterService: "opensearch-cluster-master"
+# The service that non cluster manager groups will try to connect to when joining the cluster
+# This should be set to clusterName + "-" + nodeGroup for your cluster manager group
+clusterManagerService: "opensearch-cluster-manager"
 
 # OpenSearch roles that will be applied to this nodeGroup
-# These will be set as environment variable "node.roles". E.g. node.roles=master,ingest,data,remote_cluster_client
+# These will be set as environment variable "node.roles". E.g. node.roles=cluster_manager,ingest,data,remote_cluster_client
 roles:
-  - master
+  - cluster_manager
   - ingest
   - data
   - remote_cluster_client
@@ -381,7 +381,7 @@ ingress:
 nameOverride: ""
 fullnameOverride: ""
 
-masterTerminationFix: false
+clusterManagerTerminationFix: false
 
 lifecycle: {}
   # preStop:
@@ -410,9 +410,9 @@ networkPolicy:
   ## In order for a Pod to access OpenSearch, it needs to have the following label:
   ## {{ template "uname" . }}-client: "true"
   ## Example for default configuration to access HTTP port:
-  ## opensearch-master-http-client: "true"
+  ## opensearch-cluster-manager-http-client: "true"
   ## Example for default configuration to access transport port:
-  ## opensearch-master-transport-client: "true"
+  ## opensearch-cluster-manager-transport-client: "true"
 
   http:
     enabled: false

--- a/charts/opensearch/ci/ci-rbac-enabled-values.yaml
+++ b/charts/opensearch/ci/ci-rbac-enabled-values.yaml
@@ -1,15 +1,15 @@
 ---
 clusterName: "opensearch-cluster"
-nodeGroup: "master"
+nodeGroup: "manager"
 
-# The service that non master groups will try to connect to when joining the cluster
-# This should be set to clusterName + "-" + nodeGroup for your master group
-masterService: "opensearch-cluster-master"
+# The service that non cluster manager groups will try to connect to when joining the cluster
+# This should be set to clusterName + "-" + nodeGroup for your cluster manager group
+clusterManagerService: "opensearch-cluster-manager"
 
 # OpenSearch roles that will be applied to this nodeGroup
-# These will be set as environment variable "node.roles". E.g. node.roles=master,ingest,data,remote_cluster_client
+# These will be set as environment variable "node.roles". E.g. node.roles=cluster_manager,ingest,data,remote_cluster_client
 roles:
-  - master
+  - cluster_manager
   - ingest
   - data
   - remote_cluster_client
@@ -381,7 +381,7 @@ ingress:
 nameOverride: ""
 fullnameOverride: ""
 
-masterTerminationFix: false
+clusterManagerTerminationFix: false
 
 lifecycle: {}
   # preStop:
@@ -410,9 +410,9 @@ networkPolicy:
   ## In order for a Pod to access OpenSearch, it needs to have the following label:
   ## {{ template "uname" . }}-client: "true"
   ## Example for default configuration to access HTTP port:
-  ## opensearch-master-http-client: "true"
+  ## opensearch-cluster-manager-http-client: "true"
   ## Example for default configuration to access transport port:
-  ## opensearch-master-transport-client: "true"
+  ## opensearch-cluster-manager-transport-client: "true"
 
   http:
     enabled: false

--- a/charts/opensearch/ci/ci-values.yaml
+++ b/charts/opensearch/ci/ci-values.yaml
@@ -1,15 +1,15 @@
 ---
 clusterName: "opensearch-cluster"
-nodeGroup: "master"
+nodeGroup: "manager"
 
-# The service that non master groups will try to connect to when joining the cluster
-# This should be set to clusterName + "-" + nodeGroup for your master group
-masterService: "opensearch-cluster-master"
+# The service that non cluster manager groups will try to connect to when joining the cluster
+# This should be set to clusterName + "-" + nodeGroup for your cluster manager group
+clusterManagerService: "opensearch-cluster-manager"
 
 # OpenSearch roles that will be applied to this nodeGroup
-# These will be set as environment variable "node.roles". E.g. node.roles=master,ingest,data,remote_cluster_client
+# These will be set as environment variable "node.roles". E.g. node.roles=cluster_manager,ingest,data,remote_cluster_client
 roles:
-  - master
+  - cluster_manager
   - ingest
   - data
   - remote_cluster_client
@@ -367,7 +367,7 @@ ingress:
 nameOverride: ""
 fullnameOverride: ""
 
-masterTerminationFix: false
+clusterManagerTerminationFix: false
 
 lifecycle: {}
   # preStop:
@@ -396,9 +396,9 @@ networkPolicy:
   ## In order for a Pod to access OpenSearch, it needs to have the following label:
   ## {{ template "uname" . }}-client: "true"
   ## Example for default configuration to access HTTP port:
-  ## opensearch-master-http-client: "true"
+  ## opensearch-cluster-manager-http-client: "true"
   ## Example for default configuration to access transport port:
-  ## opensearch-master-transport-client: "true"
+  ## opensearch-cluster-manager-transport-client: "true"
 
   http:
     enabled: false

--- a/charts/opensearch/templates/_helpers.tpl
+++ b/charts/opensearch/templates/_helpers.tpl
@@ -62,25 +62,25 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
-{{- define "opensearch.masterService" -}}
-{{- if empty .Values.masterService -}}
+{{- define "opensearch.clusterManagerService" -}}
+{{- if empty .Values.clusterManagerService -}}
 {{- if empty .Values.fullnameOverride -}}
 {{- if empty .Values.nameOverride -}}
-{{ .Values.clusterName }}-master
+{{ .Values.clusterName }}-manager
 {{- else -}}
-{{ .Values.nameOverride }}-master
+{{ .Values.nameOverride }}-manager
 {{- end -}}
 {{- else -}}
 {{ .Values.fullnameOverride }}
 {{- end -}}
 {{- else -}}
-{{ .Values.masterService }}
+{{ .Values.clusterManagerService }}
 {{- end -}}
 {{- end -}}
 
 {{- define "opensearch.serviceName" -}}
-{{- if eq .Values.nodeGroup "master" }}
-{{- include "opensearch.masterService" . }}
+{{- if or (eq .Values.nodeGroup "master") (eq .Values.nodeGroup "manager") }}
+{{- include "opensearch.clusterManagerService" . }}
 {{- else }}
 {{- include "opensearch.uname" . }}
 {{- end }}

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -404,12 +404,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        {{- if (and (has "master" .Values.roles) (not .Values.singleNode)) }}
-        - name: cluster.initial_master_nodes
+        {{- if (and (or (has "master" .Values.roles) (has "cluster_manager" .Values.roles)) (not .Values.singleNode)) }}
+        - name: cluster.initial_cluster_manager_nodes
           value: "{{ template "opensearch.endpoints" . }}"
         {{- end }}
         - name: discovery.seed_hosts
-          value: "{{ template "opensearch.masterService" . }}-headless"
+          value: "{{ template "opensearch.clusterManagerService" . }}-headless"
         - name: cluster.name
           value: "{{ .Values.clusterName }}"
         - name: network.host
@@ -512,10 +512,10 @@ spec:
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
         {{- end }}
         {{- end }}
-      {{- if .Values.masterTerminationFix }}
-      {{- if has "master" .Values.roles }}
-      # This sidecar will prevent slow master re-election
-      - name: opensearch-master-graceful-termination-handler
+      {{- if .Values.clusterManagerTerminationFix }}
+      {{- if or (has "master" .Values.roles) (has "cluster_manager" .Values.roles) }}
+      # This sidecar will prevent slow cluster-manager re-election
+      - name: opensearch-cluster-manager-graceful-termination-handler
         image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         command:
@@ -532,17 +532,17 @@ spec:
               else
                 BASIC_AUTH=''
               fi
-              curl -XGET -s -k --fail ${BASIC_AUTH} {{ .Values.protocol }}://{{ template "opensearch.masterService" . }}:{{ .Values.httpPort }}${path}
+              curl -XGET -s -k --fail ${BASIC_AUTH} {{ .Values.protocol }}://{{ template "opensearch.clusterManagerService" . }}:{{ .Values.httpPort }}${path}
           }
 
           cleanup () {
             while true ; do
-              local master="$(http "/_cat/master?h=node" || echo "")"
-              if [[ $master == "{{ template "opensearch.masterService" . }}"* && $master != "${NODE_NAME}" ]]; then
-                echo "This node is not master."
+              local cluster_manager="$(http "/_cat/cluster_manager?h=node" || echo "")"
+              if [[ $cluster_manager == "{{ template "opensearch.clusterManagerService" . }}"* && $cluster_manager != "${NODE_NAME}" ]]; then
+                echo "This node is not cluster-manager."
                 break
               fi
-              echo "This node is still master, waiting gracefully for it to step down"
+              echo "This node is still cluster-manager, waiting gracefully for it to step down"
               sleep 1
             done
 

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -1,20 +1,20 @@
 ---
 clusterName: "opensearch-cluster"
-nodeGroup: "master"
+nodeGroup: "manager"
 
 # If discovery.type in the opensearch configuration is set to "single-node",
 # this should be set to "true"
 # If "true", replicas will be forced to 1
 singleNode: false
 
-# The service that non master groups will try to connect to when joining the cluster
-# This should be set to clusterName + "-" + nodeGroup for your master group
-masterService: "opensearch-cluster-master"
+# The service that non cluster manager groups will try to connect to when joining the cluster
+# This should be set to clusterName + "-" + nodeGroup for your cluster manager group
+clusterManagerService: "opensearch-cluster-manager"
 
 # OpenSearch roles that will be applied to this nodeGroup
-# These will be set as environment variable "node.roles". E.g. node.roles=master,ingest,data,remote_cluster_client
+# These will be set as environment variable "node.roles". E.g. node.roles=cluster_manager,ingest,data,remote_cluster_client
 roles:
-  - master
+  - cluster_manager
   - ingest
   - data
   - remote_cluster_client
@@ -421,7 +421,7 @@ ingress:
 nameOverride: ""
 fullnameOverride: ""
 
-masterTerminationFix: false
+clusterManagerTerminationFix: false
 
 opensearchLifecycle: {}
   # preStop:
@@ -461,9 +461,9 @@ networkPolicy:
   ## In order for a Pod to access OpenSearch, it needs to have the following label:
   ## {{ template "uname" . }}-client: "true"
   ## Example for default configuration to access HTTP port:
-  ## opensearch-master-http-client: "true"
+  ## opensearch-cluster-manager-http-client: "true"
   ## Example for default configuration to access transport port:
-  ## opensearch-master-transport-client: "true"
+  ## opensearch-cluster-manager-transport-client: "true"
 
   http:
     enabled: false


### PR DESCRIPTION
### Description
This will bring the charts in line with https://opensearch.org/blog/Adopting-inclusive-language-across-OpenSearch/

Additionally it resolves the issue where a multi-replica cluster fails to perform initial discovery when you attempt to use the role from the inclusive language and deploy the chart with the following values

```
roles:
  - cluster_manager
  - ingest
  - data
  - remote_cluster_client
```

In this case, you will observe the following log message repeated a few times

```
[2024-07-16T02:47:56,461][WARN ][o.o.c.c.ClusterFormationFailureHelper] [opensearch-cluster-master-0] cluster-manager not discovered yet, this node has not previously joined a bootstrapped cluster, and [cluster.initial_cluster_manager_nodes] is empty on this node: have discovered [{opensearch-cluster-master-0}{4LevXxJKSjqPPDCHL3xQXA}{AC5gnzcwR5yR9CKGuan3Og}{10.244.1.8}{10.244.1.8:9300}{dimr}{shard_indexing_pressure_enabled=true}, {opensearch-cluster-master-1}{xw8pX8CcTBWNl2ylGCxp-w}{2XFteZTzRrOZ6ilsxJC6Ug}{10.244.3.7}{10.244.3.7:9300}{dimr}{shard_indexing_pressure_enabled=true}, {opensearch-cluster-master-2}{y_bTw1kcQWOhNyDAI2MZ7A}{tN-aAkHLTduCo6g7EsR2HQ}{10.244.2.7}{10.244.2.7:9300}{dimr}{shard_indexing_pressure_enabled=true}]; discovery will continue using [10.244.3.7:9300, 10.244.2.7:9300] from hosts providers and [{opensearch-cluster-master-0}{4LevXxJKSjqPPDCHL3xQXA}{AC5gnzcwR5yR9CKGuan3Og}{10.244.1.8}{10.244.1.8:9300}{dimr}{shard_indexing_pressure_enabled=true}] from last-known cluster state; node term 0, last-accepted version 0 in term 0
```

with this log message also repeating over and over

```
[2024-07-16T02:47:56,469][INFO ][o.o.s.c.ConfigurationRepository] [opensearch-cluster-master-0] Wait for cluster to be available ...
```
 
### Issues Resolved
https://github.com/opensearch-project/helm-charts/issues/276
https://github.com/opensearch-project/helm-charts/issues/366
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
