### PR TITLE
[Backport 1.x] Update chart-releaser-action to 1.6.0 to consume the mark_as_latest param properly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       # See https://github.com/helm/chart-releaser
       # See https://github.com/helm/chart-releaser-action
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           mark_as_latest: false
         env:


### PR DESCRIPTION


### Description
[Backport 1.x] Update chart-releaser-action to 1.6.0 to consume the mark_as_latest param properly

 
### Issues Resolved
Backport https://github.com/opensearch-project/helm-charts/pull/583
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
