### PR TITLE
feat(serviceMonitors): add option of additional Labels in serviceMonitor

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -6,816 +6,429 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-
 ## [Unreleased]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.22.0]
-
 ### Added
-
 - Ability to add additional `labels` to `serviceMonitor`
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.21.2]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Bug `protocol` missing for metrics in `Service`
-
 ### Security
-
 ---
-
 ## [2.21.1]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Fixed `ServiceMonitor` bug for `port` value
-
 ### Security
-
 ---
-
 ## [2.21.0]
-
 ### Added
-
 - Added `ServiceMonitor` support for Prometheus monitoring
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.20.0]
-
 ### Added
-
 - Updated OpenSearch Dashboards appVersion to 2.16.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.19.1]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Fixed pod topology spread constraints in Dashboards
-
 ### Security
-
 ---
-
 ## [2.19.0]
-
 ### Added
-
 - Updated OpenSearch Dashboards appVersion to 2.15.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.18.0]
-
 ### Added
-
 - Updated OpenSearch Dashboards appVersion to 2.14.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.17.0]
-
 ### Added
-
 - Updated OpenSearch Dashboards appVersion to 2.13.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.16.1]
-
 ### Added
-
 - Support for newer HorizontalPodAutoscaler api in Dashboards
 - Ability to configure HorizontalPodAutoscaler to use memory as a metric source type
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.16.0]
-
 ### Added
-
 - Updated OpenSearch Dashboards appVersion to 2.12.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.15.1]
-
 ### Added
-
 - Added support for pod topology spread constraints in Dashboards
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.15.0]
-
 ### Added
-
 - Updated OpenSearch Dashboards appVersion to 2.11.1
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.14.0]
-
 ### Added
-
 - Updated OpenSearch Dashboards appVersion to 2.11.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.13.0]
-
 ### Added
-
 - Updated OpenSearch Dashboards appVersion to 2.10.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.12.0]
-
 ### Added
-
 - Updated OpenSearch Dashboards appVersion to 2.9.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.11.1]
-
 ### Added
-
 - Support string type for extraObjects
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.11.0]
-
 ### Added
-
 - Updated OpenSearch Dashboards appVersion to 2.8.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.10.0]
-
 ### Added
-
 - Updated OpenSearch Dashboards appVersion to 2.7.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.9.3]
-
 ### Added
-
 - Added custom opensearch and dashboard annotations through values.yaml
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.9.2]
-
 ### Added
-
 - Support setting ipFamilyPolicy on Service
 - Support setting ipFamilies on Service
-
 ---
-
 ## [2.9.1]
-
 ### Added
-
 ### Changed
-
 - Allow user-defined labels on ingress resource
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.9.0]
-
 ### Added
-
 ### Changed
-
 - Updated OpenSearch Dashboards appVersion to 2.6.0
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.8.0]
-
 ### Added
-
 ### Changed
-
 - Updated OpenSearch Dashboards appVersion to 2.5.0
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.7.0]
-
 ### Added
-
 ### Changed
-
 - Updated OpenSearch Dashboards appVersion to 2.4.1
-
 ---
-
 ## [2.6.1]
-
 ### Added
-
 - Added the ability to define plugins on node startup via plugins.enabled option for opensearch-dashboards chart.
 - Added the ability to define defaultMode for the opensearch_dashboards.yml file which is mounted as configMap
 - Added documentation for new configurations
-
 ### Changed
-
 - Updated version to 2.6.1
-
 ---
-
 ## [2.6.0]
-
 ### Added
-
 ### Changed
-
 - Updated OpenSearch Dashboards appVersion to 2.4.0
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.5.3]
-
 ### Added
-
 - Startup, readiness and liveness probes for deployment
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.5.2]
-
 ### Added
-
 - Template configmap content by tpl function
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.5.1]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - ingress helm validation error fix by removing additional hyphen
-
 ### Security
-
 ---
-
 ## [2.5.0]
-
 ### Added
-
 ### Changed
-
 - Updated version to 2.5.0 and appVersion to "2.3.0".
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.4.2]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - OpenSearch Dashboards fixed failure when ingress service port is a string (named port)
-
 ### Security
-
 ---
-
 ## [2.4.1]
-
 ### Added
-
 - Helm chart-releaser parallel release issue, updated version to 2.4.1.
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.4.0]
-
 ### Added
-
 - Updated version to 2.4.0 and appVersion to "2.2.1".
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.3.0]
-
 ### Added
-
 - Updated version to 2.3.0 and appVersion to "2.2.0".
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.2.4]
-
 ### Added
-
 - Add lifecycle hooks for opensearch-dashboards charts
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.2.3]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Opensearch dashboards ingress template to use values from provided config
-
 ### Security
-
 ---
-
 ## [2.2.2]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Opensearch dashboard fix issue #295.
 - Opensearch dashboard config map support both string and map format.
-
 ### Security
-
 ---
-
 ## [2.2.1]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Opensearch dashboard config map format is restored with backward support of string format
-
 ### Security
-
 ---
-
 ## [2.2.0]
-
 ### Added
-
 ### Changed
-
 - Updated version to 2.2.0 and appVersion to "2.1.0".
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.1.0]
-
 ### Added
-
 ### Changed
-
 - Updated version to 2.1.0 and appVersion to "2.0.1".
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.0.1]
-
 ### Added
-
 ### Changed
-
 - Updated version to 2.0.1 and appVersion to "2.0.0".
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.0.0]
-
 ### Added
-
 ### Changed
-
 - Updated version to 2.0.0 and appVersion to "2.0.0-rc1".
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
 
-<<<<<<< HEAD
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.2...HEAD
-[2.21.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.1...opensearch-dashboards-2.21.2
-=======
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.1...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.22.0...HEAD
 [2.22.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.1...opensearch-dashboards-2.22.0
-
-> > > > > > > c2d1d9c (fix(CHANGELOG): add new release)
-> > > > > > > [2.21.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.0...opensearch-dashboards-2.21.1
-> > > > > > > [2.21.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.20.0...opensearch-dashboards-2.21.0
-> > > > > > > [2.20.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.19.1...opensearch-dashboards-2.20.0
-> > > > > > > [2.19.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.19.0...opensearch-dashboards-2.19.1
-> > > > > > > [2.19.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.18.0...opensearch-dashboards-2.19.0
-> > > > > > > [2.18.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.17.0...opensearch-dashboards-2.18.0
-> > > > > > > [2.17.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.16.0...opensearch-dashboards-2.17.0
-> > > > > > > [2.16.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.15.1...opensearch-dashboards-2.16.0
-> > > > > > > [2.15.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.15.0...opensearch-dashboards-2.15.1
-> > > > > > > [2.15.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.14.0...opensearch-dashboards-2.15.0
-> > > > > > > [2.14.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.13.0...opensearch-dashboards-2.14.0
-> > > > > > > [2.13.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.12.0...opensearch-dashboards-2.13.0
-> > > > > > > [2.12.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.11.1...opensearch-dashboards-2.12.0
-> > > > > > > [2.11.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.11.0...opensearch-dashboards-2.11.1
-> > > > > > > [2.11.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.10.0...opensearch-dashboards-2.11.0
-> > > > > > > [2.10.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.9.0...opensearch-dashboards-2.10.0
-> > > > > > > [2.9.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.8.0...opensearch-dashboards-2.9.0
-> > > > > > > [2.8.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.7.0...opensearch-dashboards-2.8.0
-> > > > > > > [2.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.6.1...opensearch-dashboards-2.7.0
-> > > > > > > [2.6.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.6.0...opensearch-dashboards-2.6.1
-> > > > > > > [2.6.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.3...opensearch-dashboards-2.6.0
-> > > > > > > [2.5.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.2...opensearch-dashboards-2.5.3
-> > > > > > > [2.5.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.1...opensearch-dashboards-2.5.2
-> > > > > > > [2.5.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.0...opensearch-dashboards-2.5.1
-> > > > > > > [2.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.4.1...opensearch-dashboards-2.5.0
-> > > > > > > [2.4.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.4.0...opensearch-dashboards-2.4.1
-> > > > > > > [2.4.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.3.0...opensearch-dashboards-2.4.0
-> > > > > > > [2.3.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.4...opensearch-dashboards-2.3.0
-> > > > > > > [2.2.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.3...opensearch-dashboards-2.2.4
-> > > > > > > [2.2.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.2...opensearch-dashboards-2.2.3
-> > > > > > > [2.2.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.1...opensearch-dashboards-2.2.2
-> > > > > > > [2.2.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.0...opensearch-dashboards-2.2.1
-> > > > > > > [2.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.1.0...opensearch-dashboards-2.2.0
-> > > > > > > [2.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.0.1...opensearch-dashboards-2.1.0
-> > > > > > > [2.0.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.0.0...opensearch-dashboards-2.0.1
+[2.21.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.1...opensearch-dashboards-2.21.2
+[2.21.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.0...opensearch-dashboards-2.21.1
+[2.21.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.20.0...opensearch-dashboards-2.21.0
+[2.20.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.19.1...opensearch-dashboards-2.20.0
+[2.19.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.19.0...opensearch-dashboards-2.19.1
+[2.19.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.18.0...opensearch-dashboards-2.19.0
+[2.18.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.17.0...opensearch-dashboards-2.18.0
+[2.17.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.16.0...opensearch-dashboards-2.17.0
+[2.16.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.15.1...opensearch-dashboards-2.16.0
+[2.15.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.15.0...opensearch-dashboards-2.15.1
+[2.15.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.14.0...opensearch-dashboards-2.15.0
+[2.14.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.13.0...opensearch-dashboards-2.14.0
+[2.13.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.12.0...opensearch-dashboards-2.13.0
+[2.12.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.11.1...opensearch-dashboards-2.12.0
+[2.11.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.11.0...opensearch-dashboards-2.11.1
+[2.11.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.10.0...opensearch-dashboards-2.11.0
+[2.10.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.9.0...opensearch-dashboards-2.10.0
+[2.9.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.8.0...opensearch-dashboards-2.9.0
+[2.8.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.7.0...opensearch-dashboards-2.8.0
+[2.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.6.1...opensearch-dashboards-2.7.0
+[2.6.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.6.0...opensearch-dashboards-2.6.1
+[2.6.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.3...opensearch-dashboards-2.6.0
+[2.5.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.2...opensearch-dashboards-2.5.3
+[2.5.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.1...opensearch-dashboards-2.5.2
+[2.5.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.0...opensearch-dashboards-2.5.1
+[2.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.4.1...opensearch-dashboards-2.5.0
+[2.4.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.4.0...opensearch-dashboards-2.4.1
+[2.4.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.3.0...opensearch-dashboards-2.4.0
+[2.3.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.4...opensearch-dashboards-2.3.0
+[2.2.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.3...opensearch-dashboards-2.2.4
+[2.2.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.2...opensearch-dashboards-2.2.3
+[2.2.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.1...opensearch-dashboards-2.2.2
+[2.2.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.0...opensearch-dashboards-2.2.1
+[2.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.1.0...opensearch-dashboards-2.2.0
+[2.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.0.1...opensearch-dashboards-2.1.0
+[2.0.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.0.0...opensearch-dashboards-2.0.1

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -6,420 +6,816 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+
 ## [Unreleased]
+
 ### Added
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
-### Security
----
-## [2.21.2]
-### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-- Bug `protocol` missing for metrics in `Service`
-### Security
----
-## [2.21.1]
-### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-- Fixed `ServiceMonitor` bug for `port` value
-### Security
----
-## [2.21.0]
-### Added
-- Added `ServiceMonitor` support for Prometheus monitoring
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.20.0]
-### Added
-- Updated OpenSearch Dashboards appVersion to 2.16.0
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.19.1]
-### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-- Fixed pod topology spread constraints in Dashboards
-### Security
----
-## [2.19.0]
-### Added
-- Updated OpenSearch Dashboards appVersion to 2.15.0
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.18.0]
-### Added
-- Updated OpenSearch Dashboards appVersion to 2.14.0
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.17.0]
-### Added
-- Updated OpenSearch Dashboards appVersion to 2.13.0
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.16.1]
-### Added
-- Support for newer HorizontalPodAutoscaler api in Dashboards
-- Ability to configure HorizontalPodAutoscaler to use memory as a metric source type
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.16.0]
-### Added
-- Updated OpenSearch Dashboards appVersion to 2.12.0
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.15.1]
-### Added
-- Added support for pod topology spread constraints in Dashboards
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.15.0]
-### Added
-- Updated OpenSearch Dashboards appVersion to 2.11.1
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.14.0]
-### Added
-- Updated OpenSearch Dashboards appVersion to 2.11.0
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.13.0]
-### Added
-- Updated OpenSearch Dashboards appVersion to 2.10.0
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.12.0]
-### Added
-- Updated OpenSearch Dashboards appVersion to 2.9.0
-### Changed
-### Deprecated
-### Removed
-### Fixed
+
 ### Security
 
 ---
+
+## [2.22.0]
+
+### Added
+
+- Ability to add additional `labels` to `serviceMonitor`
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.21.2]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Bug `protocol` missing for metrics in `Service`
+
+### Security
+
+---
+
+## [2.21.1]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Fixed `ServiceMonitor` bug for `port` value
+
+### Security
+
+---
+
+## [2.21.0]
+
+### Added
+
+- Added `ServiceMonitor` support for Prometheus monitoring
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.20.0]
+
+### Added
+
+- Updated OpenSearch Dashboards appVersion to 2.16.0
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.19.1]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Fixed pod topology spread constraints in Dashboards
+
+### Security
+
+---
+
+## [2.19.0]
+
+### Added
+
+- Updated OpenSearch Dashboards appVersion to 2.15.0
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.18.0]
+
+### Added
+
+- Updated OpenSearch Dashboards appVersion to 2.14.0
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.17.0]
+
+### Added
+
+- Updated OpenSearch Dashboards appVersion to 2.13.0
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.16.1]
+
+### Added
+
+- Support for newer HorizontalPodAutoscaler api in Dashboards
+- Ability to configure HorizontalPodAutoscaler to use memory as a metric source type
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.16.0]
+
+### Added
+
+- Updated OpenSearch Dashboards appVersion to 2.12.0
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.15.1]
+
+### Added
+
+- Added support for pod topology spread constraints in Dashboards
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.15.0]
+
+### Added
+
+- Updated OpenSearch Dashboards appVersion to 2.11.1
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.14.0]
+
+### Added
+
+- Updated OpenSearch Dashboards appVersion to 2.11.0
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.13.0]
+
+### Added
+
+- Updated OpenSearch Dashboards appVersion to 2.10.0
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.12.0]
+
+### Added
+
+- Updated OpenSearch Dashboards appVersion to 2.9.0
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
 ## [2.11.1]
+
 ### Added
+
 - Support string type for extraObjects
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.11.0]
+
 ### Added
+
 - Updated OpenSearch Dashboards appVersion to 2.8.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.10.0]
+
 ### Added
+
 - Updated OpenSearch Dashboards appVersion to 2.7.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.9.3]
+
 ### Added
+
 - Added custom opensearch and dashboard annotations through values.yaml
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.9.2]
+
 ### Added
+
 - Support setting ipFamilyPolicy on Service
 - Support setting ipFamilies on Service
+
 ---
+
 ## [2.9.1]
+
 ### Added
+
 ### Changed
+
 - Allow user-defined labels on ingress resource
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.9.0]
+
 ### Added
+
 ### Changed
+
 - Updated OpenSearch Dashboards appVersion to 2.6.0
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.8.0]
+
 ### Added
+
 ### Changed
+
 - Updated OpenSearch Dashboards appVersion to 2.5.0
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.7.0]
+
 ### Added
+
 ### Changed
+
 - Updated OpenSearch Dashboards appVersion to 2.4.1
+
 ---
+
 ## [2.6.1]
+
 ### Added
+
 - Added the ability to define plugins on node startup via plugins.enabled option for opensearch-dashboards chart.
 - Added the ability to define defaultMode for the opensearch_dashboards.yml file which is mounted as configMap
 - Added documentation for new configurations
+
 ### Changed
+
 - Updated version to 2.6.1
+
 ---
+
 ## [2.6.0]
+
 ### Added
+
 ### Changed
+
 - Updated OpenSearch Dashboards appVersion to 2.4.0
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
-### Security
----
-## [2.5.3]
-### Added
-- Startup, readiness and liveness probes for deployment
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.5.2]
-### Added
-- Template configmap content by tpl function
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.5.1]
-### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-- ingress helm validation error fix by removing additional hyphen
-### Security
----
-## [2.5.0]
-### Added
-### Changed
-- Updated version to 2.5.0 and appVersion to "2.3.0".
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.4.2]
-### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-- OpenSearch Dashboards fixed failure when ingress service port is a string (named port)
-### Security
----
-## [2.4.1]
-### Added
-- Helm chart-releaser parallel release issue, updated version to 2.4.1.
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.4.0]
-### Added
-- Updated version to 2.4.0 and appVersion to "2.2.1".
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.3.0]
-### Added
-- Updated version to 2.3.0 and appVersion to "2.2.0".
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.2.4]
-### Added
-- Add lifecycle hooks for opensearch-dashboards charts
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.2.3]
-### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-- Opensearch dashboards ingress template to use values from provided config
-### Security
----
-## [2.2.2]
-### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-- Opensearch dashboard fix issue #295.
-- Opensearch dashboard config map support both string and map format.
-### Security
----
-## [2.2.1]
-### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-- Opensearch dashboard config map format is restored with backward support of string format
-### Security
----
-## [2.2.0]
-### Added
-### Changed
-- Updated version to 2.2.0 and appVersion to "2.1.0".
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.1.0]
-### Added
-### Changed
-- Updated version to 2.1.0 and appVersion to "2.0.1".
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.0.1]
-### Added
-### Changed
-- Updated version to 2.0.1 and appVersion to "2.0.0".
-### Deprecated
-### Removed
-### Fixed
-### Security
----
-## [2.0.0]
-### Added
-### Changed
-- Updated version to 2.0.0 and appVersion to "2.0.0-rc1".
-### Deprecated
-### Removed
-### Fixed
+
 ### Security
 
+---
+
+## [2.5.3]
+
+### Added
+
+- Startup, readiness and liveness probes for deployment
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.5.2]
+
+### Added
+
+- Template configmap content by tpl function
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.5.1]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- ingress helm validation error fix by removing additional hyphen
+
+### Security
+
+---
+
+## [2.5.0]
+
+### Added
+
+### Changed
+
+- Updated version to 2.5.0 and appVersion to "2.3.0".
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.4.2]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- OpenSearch Dashboards fixed failure when ingress service port is a string (named port)
+
+### Security
+
+---
+
+## [2.4.1]
+
+### Added
+
+- Helm chart-releaser parallel release issue, updated version to 2.4.1.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.4.0]
+
+### Added
+
+- Updated version to 2.4.0 and appVersion to "2.2.1".
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.3.0]
+
+### Added
+
+- Updated version to 2.3.0 and appVersion to "2.2.0".
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.2.4]
+
+### Added
+
+- Add lifecycle hooks for opensearch-dashboards charts
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.2.3]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Opensearch dashboards ingress template to use values from provided config
+
+### Security
+
+---
+
+## [2.2.2]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Opensearch dashboard fix issue #295.
+- Opensearch dashboard config map support both string and map format.
+
+### Security
+
+---
+
+## [2.2.1]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Opensearch dashboard config map format is restored with backward support of string format
+
+### Security
+
+---
+
+## [2.2.0]
+
+### Added
+
+### Changed
+
+- Updated version to 2.2.0 and appVersion to "2.1.0".
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.1.0]
+
+### Added
+
+### Changed
+
+- Updated version to 2.1.0 and appVersion to "2.0.1".
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.0.1]
+
+### Added
+
+### Changed
+
+- Updated version to 2.0.1 and appVersion to "2.0.0".
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [2.0.0]
+
+### Added
+
+### Changed
+
+- Updated version to 2.0.0 and appVersion to "2.0.0-rc1".
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+<<<<<<< HEAD
 [Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.2...HEAD
 [2.21.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.1...opensearch-dashboards-2.21.2
-[2.21.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.0...opensearch-dashboards-2.21.1
-[2.21.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.20.0...opensearch-dashboards-2.21.0
-[2.20.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.19.1...opensearch-dashboards-2.20.0
-[2.19.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.19.0...opensearch-dashboards-2.19.1
-[2.19.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.18.0...opensearch-dashboards-2.19.0
-[2.18.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.17.0...opensearch-dashboards-2.18.0
-[2.17.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.16.0...opensearch-dashboards-2.17.0
-[2.16.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.15.1...opensearch-dashboards-2.16.0
-[2.15.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.15.0...opensearch-dashboards-2.15.1
-[2.15.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.14.0...opensearch-dashboards-2.15.0
-[2.14.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.13.0...opensearch-dashboards-2.14.0
-[2.13.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.12.0...opensearch-dashboards-2.13.0
-[2.12.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.11.1...opensearch-dashboards-2.12.0
-[2.11.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.11.0...opensearch-dashboards-2.11.1
-[2.11.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.10.0...opensearch-dashboards-2.11.0
-[2.10.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.9.0...opensearch-dashboards-2.10.0
-[2.9.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.8.0...opensearch-dashboards-2.9.0
-[2.8.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.7.0...opensearch-dashboards-2.8.0
-[2.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.6.1...opensearch-dashboards-2.7.0
-[2.6.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.6.0...opensearch-dashboards-2.6.1
-[2.6.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.3...opensearch-dashboards-2.6.0
-[2.5.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.2...opensearch-dashboards-2.5.3
-[2.5.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.1...opensearch-dashboards-2.5.2
-[2.5.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.0...opensearch-dashboards-2.5.1
-[2.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.4.1...opensearch-dashboards-2.5.0
-[2.4.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.4.0...opensearch-dashboards-2.4.1
-[2.4.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.3.0...opensearch-dashboards-2.4.0
-[2.3.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.4...opensearch-dashboards-2.3.0
-[2.2.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.3...opensearch-dashboards-2.2.4
-[2.2.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.2...opensearch-dashboards-2.2.3
-[2.2.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.1...opensearch-dashboards-2.2.2
-[2.2.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.0...opensearch-dashboards-2.2.1
-[2.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.1.0...opensearch-dashboards-2.2.0
-[2.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.0.1...opensearch-dashboards-2.1.0
-[2.0.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.0.0...opensearch-dashboards-2.0.1
+=======
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.1...HEAD
+[2.22.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.1...opensearch-dashboards-2.22.0
+
+> > > > > > > c2d1d9c (fix(CHANGELOG): add new release)
+> > > > > > > [2.21.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.0...opensearch-dashboards-2.21.1
+> > > > > > > [2.21.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.20.0...opensearch-dashboards-2.21.0
+> > > > > > > [2.20.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.19.1...opensearch-dashboards-2.20.0
+> > > > > > > [2.19.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.19.0...opensearch-dashboards-2.19.1
+> > > > > > > [2.19.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.18.0...opensearch-dashboards-2.19.0
+> > > > > > > [2.18.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.17.0...opensearch-dashboards-2.18.0
+> > > > > > > [2.17.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.16.0...opensearch-dashboards-2.17.0
+> > > > > > > [2.16.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.15.1...opensearch-dashboards-2.16.0
+> > > > > > > [2.15.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.15.0...opensearch-dashboards-2.15.1
+> > > > > > > [2.15.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.14.0...opensearch-dashboards-2.15.0
+> > > > > > > [2.14.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.13.0...opensearch-dashboards-2.14.0
+> > > > > > > [2.13.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.12.0...opensearch-dashboards-2.13.0
+> > > > > > > [2.12.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.11.1...opensearch-dashboards-2.12.0
+> > > > > > > [2.11.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.11.0...opensearch-dashboards-2.11.1
+> > > > > > > [2.11.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.10.0...opensearch-dashboards-2.11.0
+> > > > > > > [2.10.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.9.0...opensearch-dashboards-2.10.0
+> > > > > > > [2.9.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.8.0...opensearch-dashboards-2.9.0
+> > > > > > > [2.8.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.7.0...opensearch-dashboards-2.8.0
+> > > > > > > [2.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.6.1...opensearch-dashboards-2.7.0
+> > > > > > > [2.6.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.6.0...opensearch-dashboards-2.6.1
+> > > > > > > [2.6.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.3...opensearch-dashboards-2.6.0
+> > > > > > > [2.5.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.2...opensearch-dashboards-2.5.3
+> > > > > > > [2.5.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.1...opensearch-dashboards-2.5.2
+> > > > > > > [2.5.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.5.0...opensearch-dashboards-2.5.1
+> > > > > > > [2.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.4.1...opensearch-dashboards-2.5.0
+> > > > > > > [2.4.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.4.0...opensearch-dashboards-2.4.1
+> > > > > > > [2.4.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.3.0...opensearch-dashboards-2.4.0
+> > > > > > > [2.3.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.4...opensearch-dashboards-2.3.0
+> > > > > > > [2.2.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.3...opensearch-dashboards-2.2.4
+> > > > > > > [2.2.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.2...opensearch-dashboards-2.2.3
+> > > > > > > [2.2.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.1...opensearch-dashboards-2.2.2
+> > > > > > > [2.2.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.2.0...opensearch-dashboards-2.2.1
+> > > > > > > [2.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.1.0...opensearch-dashboards-2.2.0
+> > > > > > > [2.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.0.1...opensearch-dashboards-2.1.0
+> > > > > > > [2.0.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.0.0...opensearch-dashboards-2.0.1

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.21.2
+version: 2.22.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/serviceMonitor.yaml
+++ b/charts/opensearch-dashboards/templates/serviceMonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch-dashboards.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -292,3 +292,6 @@ serviceMonitor:
   # Frequency at which Prometheus will scrape metrics.
   # Modify as needed for your monitoring requirements.
   interval: 10s
+
+  # additional labels to be added to the ServiceMonitor
+  labels: {}

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -294,4 +294,6 @@ serviceMonitor:
   interval: 10s
 
   # additional labels to be added to the ServiceMonitor
+  # labels:
+  #  k8s.example.com/prometheus: kube-prometheus
   labels: {}

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -6,515 +6,994 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+
 ## [Unreleased]
+
 ### Added
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
+## [2.24.0]
+
+### Added
+
+- Ability to add additional `labels` to `serviceMonitor`
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
 ## [2.23.2]
+
 ### Added
+
 - Metrics configuration in both `Service` templates
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 - Bug `protocol` missing for metrics in `Service`
+
 ### Security
+
 ---
+
 ## [2.23.1]
+
 ### Added
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 - Fixed `ServiceMonitor` bug for `port` value
+
 ### Security
+
 ---
+
 ## [2.23.0]
+
 ### Added
+
 - Added `ServiceMonitor` support for Prometheus monitoring
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.22.1]
+
 ### Added
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
-- Fixed opensearchJavaOpts defaults in README 
+
+- Fixed opensearchJavaOpts defaults in README
+
 ### Security
+
 ---
+
 ## [2.22.0]
+
 ### Added
+
 - Updated OpenSearch appVersion to 2.16.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
 
 ## [2.21.0]
+
 ### Added
+
 - Updated OpenSearch appVersion to 2.15.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.20.0]
+
 ### Added
+
 - Updated OpenSearch appVersion to 2.14.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.19.0]
+
 ### Added
+
 - Updated OpenSearch appVersion to 2.13.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.18.0]
+
 ### Added
+
 ### Breaking
- - Requires an initial admin password to be setup starting from App Version OpenSearch 2.12.0. Refer this github issue: https://github.com/opensearch-project/security/issues/3622
- - Updated OpenSearch appVersion to 2.12.0
+
+- Requires an initial admin password to be setup starting from App Version OpenSearch 2.12.0. Refer this github issue: https://github.com/opensearch-project/security/issues/3622
+- Updated OpenSearch appVersion to 2.12.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.17.3]
+
 ### Added
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 - Bug `opensearch.yml` configMap Read-only file system error.
+
 ### Security
+
 ---
+
 ## [2.17.2]
+
 ### Added
+
 - - Allow user-defined labels on ingress resource
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.17.1]
+
 ### Added
+
 - Added ability to specify custom pod anti-affinity and pod affinity
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.17.0]
+
 ### Added
+
 - Updated OpenSearch appVersion to 2.11.1
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.16.1]
+
 ### Added
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 - Fixed missing lifecycle parameter in README for opensearch chart
+
 ### Security
+
 ---
+
 ## [2.16.0]
+
 ### Added
+
 - Updated OpenSearch appVersion to 2.11.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.15.0]
+
 ### Added
+
 - Updated OpenSearch appVersion to 2.10.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.14.1]
+
 ### Added
+
 - Add homepage and source urls to chart
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.14.0]
+
 ### Added
+
 - Updated OpenSearch appVersion to 2.9.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.13.3]
+
 ### Added
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 - Correct variable name in keystore import
+
 ### Security
+
 ---
+
 ## [2.13.2]
+
 ### Added
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 - Avoid CrashLoop when keystore secret has no data
+
 ### Security
+
 ---
+
 ## [2.13.1]
+
 ### Added
+
 - Support string type for extraObjects
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.13.0]
+
 ### Added
+
 - Updated OpenSearch appVersion to 2.8.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.12.2]
+
 ### Added
+
 - Support for toggling automountServiceAccountToken to comply with strict Kubernetes Policies
+
 ### Changed
+
 - if/else logic for serviceAccountName to be more intelligent
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 - Whitespace under Resources blocks that was causing linting errors
+
 ### Security
+
 ---
+
 ## [2.12.1]
+
 ### Added
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 - Add imagePullPolicy to fsgroup-volume init container
+
 ### Security
+
 ---
+
 ## [2.12.0]
+
 ### Added
+
 - Updated OpenSearch appVersion to 2.7.0
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 - Add imagePullPolicy to fsgroup-volume init container
+
 ### Security
+
 ---
+
 ## [2.11.5]
+
 ### Added
+
 - Update the Readme and comments section.
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.11.4]
+
 ### Added
+
 - Added custom opensearch deployment annotation through values.yaml
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.11.3]
+
 ### Added
+
 - Support setting ipFamilyPolicy on Service
 - Support setting ipFamilies on Service
+
 ---
+
 ## [2.11.2]
+
 ### Added
+
 - Service ports for performance analyzer
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.11.1]
+
 ### Added
+
 - Support for lifecycle in the opensearch container in the StatefulSet
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.11.0]
+
 ### Added
+
 ### Changed
+
 - Updated OpenSearch appVersion to 2.6.0
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.10.0]
+
 ### Added
+
 ### Changed
+
 - Updated OpenSearch appVersion to 2.5.0
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.9.1]
+
 ### Added
+
 - Support for http- and transport-hostPort
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.9.0]
+
 ### Added
+
 ### Changed
+
 - Updated OpenSearch appVersion to 2.4.1
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.8.2]
+
 ### Added
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 - Fix path in securityConfig section, it was changed in ver.2. See: [Issue #127](https://github.com/opensearch-project/opensearch-plugins/issues/127)
+
 ### Security
+
 ---
+
 ## [2.8.1]
+
 ### Added
+
 - added "plugins.enabled" and "plugins.installList" to the readme
+
 ### Changed
+
 - Bumped version to 2.8.1
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.8.0]
+
 ### Added
+
 ### Changed
+
 - Updated OpenSearch appVersion to 2.4.0
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.7.0]
+
 ### Added
+
 - Add option to enable the use of `sysctlInit` to set sysctl vm.max_map_count through privileged `initContainer`. See: [Issue #87](https://github.com/opensearch-project/helm-charts/issues/87)
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.6.2]
+
 ### Added
+
 - Liveness probe for statefulset
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.6.1]
+
 ### Added
+
 - Template configmap content by tpl function
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.6.0]
+
 ### Added
+
 ### Changed
+
 - Updated version to 2.6.0 and appVersion to "2.3.0".
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.5.1]
+
 ### Added
+
 - Helm chart-releaser parallel release issue, updated version to 2.5.1.
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.5.0]
+
 ### Added
+
 - Updated version to 2.5.0 and appVersion to "2.2.1".
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.4.1]
+
 ### Added
+
 - Add "singleNode" feature to disable the "cluster.initial_master_nodes" env var
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.4.0]
+
 ### Added
+
 - Updated version to 2.4.0 and appVersion to "2.2.0".
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.3.0]
+
 ### Added
+
 - Updated version to 2.3.0 and appVersion to "2.1.0".
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.2.0]
+
 ### Added
+
 - Add feature for readinessProbe and startupProbe
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.1.0]
+
 ### Added
+
 ### Changed
+
 - Updated version to 2.1.0 and appVersion to "2.0.1".
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.0.1]
+
 ### Added
+
 ### Changed
+
 - Updated version to 2.0.1 and appVersion to "2.0.0".
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ---
+
 ## [2.0.0]
+
 ### Added
+
 ### Changed
+
 - Updated version to 2.0.0 and appVersion to "2.0.0-rc1".
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
 
-
+<<<<<<< HEAD
 [Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.2...HEAD
 [2.23.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.1...opensearch-2.23.2
-[2.23.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.0...opensearch-2.23.1
-[2.23.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.22.1...opensearch-2.23.0
-[2.22.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.22.0...opensearch-2.22.1
-[2.22.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.21.0...opensearch-2.22.0
-[2.21.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.20.0...opensearch-2.21.0
-[2.20.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.19.0...opensearch-2.20.0
-[2.19.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.18.0...opensearch-2.19.0
-[2.18.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.3...opensearch-2.18.0
-[2.17.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.2...opensearch-2.17.3
-[2.17.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.1...opensearch-2.17.2
-[2.17.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.0...opensearch-2.17.1
-[2.17.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.16.1...opensearch-2.17.0
-[2.16.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.16.0...opensearch-2.16.1
-[2.16.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.15.0...opensearch-2.16.0
-[2.15.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.14.1...opensearch-2.15.0
-[2.14.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.14.0...opensearch-2.14.1
-[2.14.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.3...opensearch-2.14.0
-[2.13.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.1...opensearch-2.13.3
-[2.13.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.1...opensearch-2.13.2
-[2.13.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.0...opensearch-2.13.1
-[2.13.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.12.0...opensearch-2.13.0
-[2.12.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.5...opensearch-2.12.0
-[2.11.5]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.4...opensearch-2.11.5
-[2.11.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.3...opensearch-2.11.4
-[2.11.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.2...opensearch-2.11.3
-[2.11.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.1...opensearch-2.11.2
-[2.11.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.0...opensearch-2.11.1
-[2.11.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.10.0...opensearch-2.11.0
-[2.10.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.9.1...opensearch-2.10.0
-[2.9.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.9.0...opensearch-2.9.1
-[2.9.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.2...opensearch-2.9.0
-[2.8.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.1...opensearch-2.8.2
-[2.8.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.0...opensearch-2.8.1
-[2.8.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.7.0...opensearch-2.8.0
-[2.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.1...opensearch-2.7.0
-[2.6.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.1...opensearch-2.6.2
-[2.6.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.0...opensearch-2.6.1
-[2.6.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.5.0...opensearch-2.6.0
-[2.5.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.5.0...opensearch-2.5.1
-[2.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.4.1...opensearch-2.5.0
-[2.4.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.4.0...opensearch-2.4.1
-[2.4.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.3.0...opensearch-2.4.0
-[2.3.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.2.0...opensearch-2.3.0
-[2.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.1.0...opensearch-2.2.0
-[2.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.0.1...opensearch-2.1.0
-[2.0.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.0.0...opensearch-2.0.1
+=======
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.1...HEAD
+[2.24.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.1...opensearch-2.24.0
 
+> > > > > > > c2d1d9c (fix(CHANGELOG): add new release)
+> > > > > > > [2.23.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.0...opensearch-2.23.1
+> > > > > > > [2.23.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.22.1...opensearch-2.23.0
+> > > > > > > [2.22.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.22.0...opensearch-2.22.1
+> > > > > > > [2.22.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.21.0...opensearch-2.22.0
+> > > > > > > [2.21.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.20.0...opensearch-2.21.0
+> > > > > > > [2.20.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.19.0...opensearch-2.20.0
+> > > > > > > [2.19.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.18.0...opensearch-2.19.0
+> > > > > > > [2.18.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.3...opensearch-2.18.0
+> > > > > > > [2.17.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.2...opensearch-2.17.3
+> > > > > > > [2.17.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.1...opensearch-2.17.2
+> > > > > > > [2.17.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.0...opensearch-2.17.1
+> > > > > > > [2.17.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.16.1...opensearch-2.17.0
+> > > > > > > [2.16.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.16.0...opensearch-2.16.1
+> > > > > > > [2.16.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.15.0...opensearch-2.16.0
+> > > > > > > [2.15.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.14.1...opensearch-2.15.0
+> > > > > > > [2.14.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.14.0...opensearch-2.14.1
+> > > > > > > [2.14.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.3...opensearch-2.14.0
+> > > > > > > [2.13.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.1...opensearch-2.13.3
+> > > > > > > [2.13.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.1...opensearch-2.13.2
+> > > > > > > [2.13.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.0...opensearch-2.13.1
+> > > > > > > [2.13.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.12.0...opensearch-2.13.0
+> > > > > > > [2.12.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.5...opensearch-2.12.0
+> > > > > > > [2.11.5]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.4...opensearch-2.11.5
+> > > > > > > [2.11.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.3...opensearch-2.11.4
+> > > > > > > [2.11.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.2...opensearch-2.11.3
+> > > > > > > [2.11.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.1...opensearch-2.11.2
+> > > > > > > [2.11.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.0...opensearch-2.11.1
+> > > > > > > [2.11.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.10.0...opensearch-2.11.0
+> > > > > > > [2.10.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.9.1...opensearch-2.10.0
+> > > > > > > [2.9.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.9.0...opensearch-2.9.1
+> > > > > > > [2.9.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.2...opensearch-2.9.0
+> > > > > > > [2.8.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.1...opensearch-2.8.2
+> > > > > > > [2.8.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.0...opensearch-2.8.1
+> > > > > > > [2.8.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.7.0...opensearch-2.8.0
+> > > > > > > [2.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.1...opensearch-2.7.0
+> > > > > > > [2.6.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.1...opensearch-2.6.2
+> > > > > > > [2.6.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.0...opensearch-2.6.1
+> > > > > > > [2.6.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.5.0...opensearch-2.6.0
+> > > > > > > [2.5.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.5.0...opensearch-2.5.1
+> > > > > > > [2.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.4.1...opensearch-2.5.0
+> > > > > > > [2.4.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.4.0...opensearch-2.4.1
+> > > > > > > [2.4.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.3.0...opensearch-2.4.0
+> > > > > > > [2.3.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.2.0...opensearch-2.3.0
+> > > > > > > [2.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.1.0...opensearch-2.2.0
+> > > > > > > [2.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.0.1...opensearch-2.1.0
+> > > > > > > [2.0.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.0.0...opensearch-2.0.1

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -6,994 +6,522 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-
 ## [Unreleased]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.24.0]
-
 ### Added
-
 - Ability to add additional `labels` to `serviceMonitor`
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.23.2]
-
 ### Added
-
 - Metrics configuration in both `Service` templates
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Bug `protocol` missing for metrics in `Service`
-
 ### Security
-
 ---
-
 ## [2.23.1]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Fixed `ServiceMonitor` bug for `port` value
-
 ### Security
-
 ---
-
 ## [2.23.0]
-
 ### Added
-
 - Added `ServiceMonitor` support for Prometheus monitoring
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.22.1]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Fixed opensearchJavaOpts defaults in README
-
 ### Security
-
 ---
-
 ## [2.22.0]
-
 ### Added
-
 - Updated OpenSearch appVersion to 2.16.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.21.0]
-
 ### Added
-
 - Updated OpenSearch appVersion to 2.15.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.20.0]
-
 ### Added
-
 - Updated OpenSearch appVersion to 2.14.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.19.0]
-
 ### Added
-
 - Updated OpenSearch appVersion to 2.13.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.18.0]
-
 ### Added
-
 ### Breaking
-
 - Requires an initial admin password to be setup starting from App Version OpenSearch 2.12.0. Refer this github issue: https://github.com/opensearch-project/security/issues/3622
 - Updated OpenSearch appVersion to 2.12.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.17.3]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Bug `opensearch.yml` configMap Read-only file system error.
-
 ### Security
-
 ---
-
 ## [2.17.2]
-
 ### Added
-
 - - Allow user-defined labels on ingress resource
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.17.1]
-
 ### Added
-
 - Added ability to specify custom pod anti-affinity and pod affinity
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.17.0]
-
 ### Added
-
 - Updated OpenSearch appVersion to 2.11.1
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.16.1]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Fixed missing lifecycle parameter in README for opensearch chart
-
 ### Security
-
 ---
-
 ## [2.16.0]
-
 ### Added
-
 - Updated OpenSearch appVersion to 2.11.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.15.0]
-
 ### Added
-
 - Updated OpenSearch appVersion to 2.10.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.14.1]
-
 ### Added
-
 - Add homepage and source urls to chart
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.14.0]
-
 ### Added
-
 - Updated OpenSearch appVersion to 2.9.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.13.3]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Correct variable name in keystore import
-
 ### Security
-
 ---
-
 ## [2.13.2]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Avoid CrashLoop when keystore secret has no data
-
 ### Security
-
 ---
-
 ## [2.13.1]
-
 ### Added
-
 - Support string type for extraObjects
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.13.0]
-
 ### Added
-
 - Updated OpenSearch appVersion to 2.8.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.12.2]
-
 ### Added
-
 - Support for toggling automountServiceAccountToken to comply with strict Kubernetes Policies
-
 ### Changed
-
 - if/else logic for serviceAccountName to be more intelligent
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Whitespace under Resources blocks that was causing linting errors
-
 ### Security
-
 ---
-
 ## [2.12.1]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Add imagePullPolicy to fsgroup-volume init container
-
 ### Security
-
 ---
-
 ## [2.12.0]
-
 ### Added
-
 - Updated OpenSearch appVersion to 2.7.0
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Add imagePullPolicy to fsgroup-volume init container
-
 ### Security
-
 ---
-
 ## [2.11.5]
-
 ### Added
-
 - Update the Readme and comments section.
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.11.4]
-
 ### Added
-
 - Added custom opensearch deployment annotation through values.yaml
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.11.3]
-
 ### Added
-
 - Support setting ipFamilyPolicy on Service
 - Support setting ipFamilies on Service
-
 ---
-
 ## [2.11.2]
-
 ### Added
-
 - Service ports for performance analyzer
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.11.1]
-
 ### Added
-
 - Support for lifecycle in the opensearch container in the StatefulSet
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.11.0]
-
 ### Added
-
 ### Changed
-
 - Updated OpenSearch appVersion to 2.6.0
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.10.0]
-
 ### Added
-
 ### Changed
-
 - Updated OpenSearch appVersion to 2.5.0
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.9.1]
-
 ### Added
-
 - Support for http- and transport-hostPort
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.9.0]
-
 ### Added
-
 ### Changed
-
 - Updated OpenSearch appVersion to 2.4.1
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.8.2]
-
 ### Added
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 - Fix path in securityConfig section, it was changed in ver.2. See: [Issue #127](https://github.com/opensearch-project/opensearch-plugins/issues/127)
-
 ### Security
-
 ---
-
 ## [2.8.1]
-
 ### Added
-
 - added "plugins.enabled" and "plugins.installList" to the readme
-
 ### Changed
-
 - Bumped version to 2.8.1
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.8.0]
-
 ### Added
-
 ### Changed
-
 - Updated OpenSearch appVersion to 2.4.0
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.7.0]
-
 ### Added
-
 - Add option to enable the use of `sysctlInit` to set sysctl vm.max_map_count through privileged `initContainer`. See: [Issue #87](https://github.com/opensearch-project/helm-charts/issues/87)
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.6.2]
-
 ### Added
-
 - Liveness probe for statefulset
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.6.1]
-
 ### Added
-
 - Template configmap content by tpl function
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.6.0]
-
 ### Added
-
 ### Changed
-
 - Updated version to 2.6.0 and appVersion to "2.3.0".
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.5.1]
-
 ### Added
-
 - Helm chart-releaser parallel release issue, updated version to 2.5.1.
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.5.0]
-
 ### Added
-
 - Updated version to 2.5.0 and appVersion to "2.2.1".
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.4.1]
-
 ### Added
-
 - Add "singleNode" feature to disable the "cluster.initial_master_nodes" env var
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.4.0]
-
 ### Added
-
 - Updated version to 2.4.0 and appVersion to "2.2.0".
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.3.0]
-
 ### Added
-
 - Updated version to 2.3.0 and appVersion to "2.1.0".
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.2.0]
-
 ### Added
-
 - Add feature for readinessProbe and startupProbe
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.1.0]
-
 ### Added
-
 ### Changed
-
 - Updated version to 2.1.0 and appVersion to "2.0.1".
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.0.1]
-
 ### Added
-
 ### Changed
-
 - Updated version to 2.0.1 and appVersion to "2.0.0".
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
-
 ---
-
 ## [2.0.0]
-
 ### Added
-
 ### Changed
-
 - Updated version to 2.0.0 and appVersion to "2.0.0-rc1".
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Security
 
-<<<<<<< HEAD
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.2...HEAD
-[2.23.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.1...opensearch-2.23.2
-=======
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.1...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.24.0...HEAD
 [2.24.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.1...opensearch-2.24.0
-
-> > > > > > > c2d1d9c (fix(CHANGELOG): add new release)
-> > > > > > > [2.23.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.0...opensearch-2.23.1
-> > > > > > > [2.23.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.22.1...opensearch-2.23.0
-> > > > > > > [2.22.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.22.0...opensearch-2.22.1
-> > > > > > > [2.22.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.21.0...opensearch-2.22.0
-> > > > > > > [2.21.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.20.0...opensearch-2.21.0
-> > > > > > > [2.20.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.19.0...opensearch-2.20.0
-> > > > > > > [2.19.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.18.0...opensearch-2.19.0
-> > > > > > > [2.18.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.3...opensearch-2.18.0
-> > > > > > > [2.17.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.2...opensearch-2.17.3
-> > > > > > > [2.17.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.1...opensearch-2.17.2
-> > > > > > > [2.17.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.0...opensearch-2.17.1
-> > > > > > > [2.17.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.16.1...opensearch-2.17.0
-> > > > > > > [2.16.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.16.0...opensearch-2.16.1
-> > > > > > > [2.16.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.15.0...opensearch-2.16.0
-> > > > > > > [2.15.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.14.1...opensearch-2.15.0
-> > > > > > > [2.14.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.14.0...opensearch-2.14.1
-> > > > > > > [2.14.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.3...opensearch-2.14.0
-> > > > > > > [2.13.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.1...opensearch-2.13.3
-> > > > > > > [2.13.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.1...opensearch-2.13.2
-> > > > > > > [2.13.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.0...opensearch-2.13.1
-> > > > > > > [2.13.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.12.0...opensearch-2.13.0
-> > > > > > > [2.12.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.5...opensearch-2.12.0
-> > > > > > > [2.11.5]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.4...opensearch-2.11.5
-> > > > > > > [2.11.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.3...opensearch-2.11.4
-> > > > > > > [2.11.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.2...opensearch-2.11.3
-> > > > > > > [2.11.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.1...opensearch-2.11.2
-> > > > > > > [2.11.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.0...opensearch-2.11.1
-> > > > > > > [2.11.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.10.0...opensearch-2.11.0
-> > > > > > > [2.10.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.9.1...opensearch-2.10.0
-> > > > > > > [2.9.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.9.0...opensearch-2.9.1
-> > > > > > > [2.9.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.2...opensearch-2.9.0
-> > > > > > > [2.8.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.1...opensearch-2.8.2
-> > > > > > > [2.8.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.0...opensearch-2.8.1
-> > > > > > > [2.8.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.7.0...opensearch-2.8.0
-> > > > > > > [2.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.1...opensearch-2.7.0
-> > > > > > > [2.6.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.1...opensearch-2.6.2
-> > > > > > > [2.6.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.0...opensearch-2.6.1
-> > > > > > > [2.6.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.5.0...opensearch-2.6.0
-> > > > > > > [2.5.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.5.0...opensearch-2.5.1
-> > > > > > > [2.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.4.1...opensearch-2.5.0
-> > > > > > > [2.4.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.4.0...opensearch-2.4.1
-> > > > > > > [2.4.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.3.0...opensearch-2.4.0
-> > > > > > > [2.3.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.2.0...opensearch-2.3.0
-> > > > > > > [2.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.1.0...opensearch-2.2.0
-> > > > > > > [2.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.0.1...opensearch-2.1.0
-> > > > > > > [2.0.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.0.0...opensearch-2.0.1
+[2.23.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.1...opensearch-2.23.2
+[2.23.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.23.0...opensearch-2.23.1
+[2.23.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.22.1...opensearch-2.23.0
+[2.22.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.22.0...opensearch-2.22.1
+[2.22.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.21.0...opensearch-2.22.0
+[2.21.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.20.0...opensearch-2.21.0
+[2.20.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.19.0...opensearch-2.20.0
+[2.19.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.18.0...opensearch-2.19.0
+[2.18.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.3...opensearch-2.18.0
+[2.17.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.2...opensearch-2.17.3
+[2.17.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.1...opensearch-2.17.2
+[2.17.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.17.0...opensearch-2.17.1
+[2.17.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.16.1...opensearch-2.17.0
+[2.16.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.16.0...opensearch-2.16.1
+[2.16.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.15.0...opensearch-2.16.0
+[2.15.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.14.1...opensearch-2.15.0
+[2.14.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.14.0...opensearch-2.14.1
+[2.14.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.3...opensearch-2.14.0
+[2.13.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.1...opensearch-2.13.3
+[2.13.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.1...opensearch-2.13.2
+[2.13.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.13.0...opensearch-2.13.1
+[2.13.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.12.0...opensearch-2.13.0
+[2.12.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.5...opensearch-2.12.0
+[2.11.5]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.4...opensearch-2.11.5
+[2.11.4]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.3...opensearch-2.11.4
+[2.11.3]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.2...opensearch-2.11.3
+[2.11.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.1...opensearch-2.11.2
+[2.11.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.11.0...opensearch-2.11.1
+[2.11.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.10.0...opensearch-2.11.0
+[2.10.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.9.1...opensearch-2.10.0
+[2.9.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.9.0...opensearch-2.9.1
+[2.9.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.2...opensearch-2.9.0
+[2.8.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.1...opensearch-2.8.2
+[2.8.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.8.0...opensearch-2.8.1
+[2.8.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.7.0...opensearch-2.8.0
+[2.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.1...opensearch-2.7.0
+[2.6.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.1...opensearch-2.6.2
+[2.6.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.6.0...opensearch-2.6.1
+[2.6.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.5.0...opensearch-2.6.0
+[2.5.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.5.0...opensearch-2.5.1
+[2.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.4.1...opensearch-2.5.0
+[2.4.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.4.0...opensearch-2.4.1
+[2.4.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.3.0...opensearch-2.4.0
+[2.3.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.2.0...opensearch-2.3.0
+[2.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.1.0...opensearch-2.2.0
+[2.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.0.1...opensearch-2.1.0
+[2.0.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.0.0...opensearch-2.0.1

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.23.2
+version: 2.24.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/serviceMonitor.yaml
+++ b/charts/opensearch/templates/serviceMonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -545,4 +545,6 @@ serviceMonitor:
   interval: 10s
 
   # additional labels to be added to the ServiceMonitor
+  # labels:
+  #  k8s.example.com/prometheus: kube-prometheus
   labels: {}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -543,3 +543,6 @@ serviceMonitor:
   # Frequency at which Prometheus will scrape metrics.
   # Adjust based on your needs.
   interval: 10s
+
+  # additional labels to be added to the ServiceMonitor
+  labels: {}


### PR DESCRIPTION
### Description

Adds ability to add additional Labels to ServiceMonitor in case Prometheus is scraping for specific labels

### Issues Resolved

#585  

### Check List

- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:

- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
