### PR TITLE
[Backport 1.x]  Add additional labels to service monitor

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.24.0]
+### Added
+- Ability to add additional `labels` to `serviceMonitor`
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.23.0]
 ### Added
 - Added `ServiceMonitor` support for Prometheus monitoring
@@ -187,7 +196,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [1.8.4]
 ### Added
-- Healthchecks 
+- Healthchecks
 ### Changed
 ### Deprecated
 ### Removed
@@ -275,7 +284,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.6.1]
 ### Added
@@ -285,7 +293,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.6.0]
 ### Added
@@ -295,7 +302,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.5.1]
 ### Added
@@ -382,7 +388,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed rendering of `opensearch-dashboard.yml` in `configmap.yaml`.
 ### Security
-
 ---
 ## [1.2.0]
 ### Added
@@ -392,7 +397,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.1.2]
 ### Added
@@ -402,7 +406,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.1.1]
 ### Added
@@ -412,7 +415,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.1.0]
 ### Added
@@ -422,7 +424,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.0.8]
 ### Added
@@ -432,7 +433,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.0.7]
 ### Added
@@ -442,7 +442,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.0.6]
 ### Added
@@ -452,7 +451,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.0.5]
 ### Added
@@ -462,7 +460,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.0.4]
 ### Added
@@ -472,22 +469,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.0.2]
-
 ### Added
 - Added this change log in compliance with [Keep A Change Log](https://keepachangelog.com/en/1.0.0/).
-
 ### Changed
 - Incremented the version to `1.0.2`.
-
 ### Deprecated
 ### Removed
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.23.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.24.0...HEAD
+[1.24.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.22.0...opensearch-1.24.0
 [1.23.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.22.0...opensearch-1.23.0
 [1.22.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.21.0...opensearch-1.22.0
 [1.21.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.20.0...opensearch-1.21.0

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -481,7 +481,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 [Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-1.24.0...HEAD
-[1.24.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.22.0...opensearch-1.24.0
+[1.24.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.23.0...opensearch-1.24.0
 [1.23.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.22.0...opensearch-1.23.0
 [1.22.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.21.0...opensearch-1.22.0
 [1.21.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.20.0...opensearch-1.21.0

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.23.0
+version: 1.24.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/serviceMonitor.yaml
+++ b/charts/opensearch-dashboards/templates/serviceMonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch-dashboards.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -286,3 +286,8 @@ serviceMonitor:
   # Frequency at which Prometheus will scrape metrics.
   # Modify as needed for your monitoring requirements.
   interval: 10s
+
+  # additional labels to be added to the ServiceMonitor
+  # labels:
+  #  k8s.example.com/prometheus: kube-prometheus
+  labels: {}

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.31.0]
+### Added
+- Ability to add additional `labels` to `serviceMonitor`
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.30.0]
 ### Added
 - Added `ServiceMonitor` support for Prometheus monitoring
@@ -266,7 +275,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
-
 ## [1.14.0]
 ### Added
 - Update OpenSearch appVersion to 1.3.5.
@@ -479,10 +487,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 **BREAKING CHANGE**
 This version introduces a change in the service name definitions that will break Helm upgrades due to changes in the `StatefulSet`.
-
 To resolve: Simply delete the existing statefulset in the cluster and ensure the PVC is retained (by default, this should be the case). `kubectl delete sts opensearch-cluster-master`
 After deleting the statefulset and upgrading the helm chart again, the new replacement statefulset will be created and should consume the same PVC as before.
-
 ### Changed
 ### Deprecated
 ### Removed
@@ -542,7 +548,6 @@ After deleting the statefulset and upgrading the helm chart again, the new repla
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.4.3]
 ### Added
@@ -552,7 +557,6 @@ After deleting the statefulset and upgrading the helm chart again, the new repla
 ### Fixed
 - Fixed links to values.yaml in README.md.
 ### Security
-
 ---
 ## [1.4.2]
 ### Added
@@ -577,14 +581,12 @@ After deleting the statefulset and upgrading the helm chart again, the new repla
 - Changed support for any kind of configuration type. Including `log4j2.properties` file. Added example.
 ### BREAKING CHANGE
 - `.Values.config` items must now be interpreted as a string. Existing items must now be updated from YAML to string:
-
 Change from YAML:
 ```yaml
 config:
   opensearch.yml:
     cluster.name: opensearch-cluster
 ```
-
 Change to YAML multiline string:
 ```yaml
 config:
@@ -622,7 +624,6 @@ config:
 ## [1.2.3]
 ### Added
 - Support to disable the initContainer `fsgroup-volume` for chown updates.
-
 ---
 ## [1.2.2]
 ### Added
@@ -632,7 +633,6 @@ config:
 ### Fixed
 - [Issue #105](https://github.com/opensearch-project/helm-charts/issues/105) OpenSearch chart fails when RBAC is enabled.
 ### Security
-
 ---
 ## [1.2.1]
 ### Added
@@ -642,7 +642,6 @@ config:
 ### Fixed
 - Missing `labels` key is added into role.yaml.
 ### Security
-
 ---
 ## [1.2.0]
 ### Added
@@ -652,7 +651,6 @@ config:
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.1.0]
 ### Added
@@ -662,7 +660,6 @@ config:
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.0.8]
 ### Added
@@ -673,17 +670,12 @@ config:
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.0.6]
-
 ### Added
 - Added the ability to define plugins on node startup via plugins.enabled option.
-
 ### Changed
 - Incremented the version to `1.0.6`.
-
-
 ---
 ## [1.0.5]
 ### Added
@@ -693,7 +685,6 @@ config:
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.0.5]
 ### Added
@@ -703,7 +694,6 @@ config:
 ### Removed
 ### Fixed
 ### Security
-
 ---
 ## [1.0.4]
 ### Added
@@ -714,22 +704,19 @@ config:
 ### Fixed
 - [ISSUE-65](https://github.com/opensearch-project/helm-charts/issues/65): Incorrect indentation for `extraVolumeMounts`, `extraEnvs`, `envFrom` in `statefulset.yaml`.
 ### Security
-
 ---
 ## [1.0.2]
-
 ### Added
 - Added this change log in compliance with [Keep A Change Log](https://keepachangelog.com/en/1.0.0/).
-
 ### Changed
 - Incremented the version to `1.0.2`.
-
 ### Deprecated
 ### Removed
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.30.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.31.0...HEAD
+[1.31.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.29.0...opensearch-1.31.0
 [1.30.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.29.0...opensearch-1.30.0
 [1.29.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.28.1...opensearch-1.29.0
 [1.28.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.28.0...opensearch-1.28.1

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -716,7 +716,7 @@ config:
 ### Security
 
 [Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.31.0...HEAD
-[1.31.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.29.0...opensearch-1.31.0
+[1.31.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.30.0...opensearch-1.31.0
 [1.30.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.29.0...opensearch-1.30.0
 [1.29.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.28.1...opensearch-1.29.0
 [1.28.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.28.0...opensearch-1.28.1

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.30.0
+version: 1.31.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/serviceMonitor.yaml
+++ b/charts/opensearch/templates/serviceMonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -523,3 +523,8 @@ serviceMonitor:
   # Frequency at which Prometheus will scrape metrics.
   # Adjust based on your needs.
   interval: 10s
+
+  # additional labels to be added to the ServiceMonitor
+  # labels:
+  #  k8s.example.com/prometheus: kube-prometheus
+  labels: {}


### PR DESCRIPTION
### Description

Adds ability to add additional Labels to ServiceMonitor in case Prometheus is scraping for specific labels

### Issues Resolved

Closes #585  

### Check List

- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:

- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
