### PR TITLE
fix(chart/opensearch): metricsPort and plugins usage info in values.yaml

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.28.0]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Fix metricsPort and plugins usage info in values.yaml
+### Security
+---
 ## [2.27.1]
 ### Added
 ### Changed
@@ -530,7 +539,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.27.1...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.28.0...HEAD
+[2.28.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.27.1...opensearch-2.28.0
 [2.27.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.27.0...opensearch-2.27.1
 [2.27.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.1...opensearch-2.27.0
 [2.26.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.0...opensearch-2.26.1

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.27.1
+version: 2.28.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.28.1
+version: 2.28.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/serviceMonitor.yaml
+++ b/charts/opensearch/templates/serviceMonitor.yaml
@@ -14,7 +14,7 @@ spec:
     matchLabels:
       {{- include "opensearch.selectorLabels" . | nindent 6 }}
   endpoints:
-  - port: {{ .Values.service.metricsPortName | default "metrics" }}
+  - port: {{ .Values.service.httpPortName | default "http" }}
     interval: {{ .Values.serviceMonitor.interval }}
     path: {{ .Values.serviceMonitor.path }}
 {{- end }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -281,7 +281,7 @@ enableServiceLinks: true
 protocol: https
 httpPort: 9200
 transportPort: 9300
-metricsPort: 9600
+metricsPort: 9200
 httpHostPort: ""
 transportHostPort: ""
 
@@ -534,6 +534,12 @@ extraObjects: []
 
 # ServiceMonitor Configuration for Prometheus
 # Enabling this option will create a ServiceMonitor resource that allows Prometheus to scrape metrics from the OpenSearch service.
+# This only creates the serviceMonitor, to actually have metrics Make sure to install the prometheus-exporter plugin needed for 
+# serving metrics over the `.Values.plugins` value:
+# plugins:
+#   enabled: true
+#   installList:
+#     - https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/x.x.x.x/prometheus-exporter-x.x.x.x.zip
 serviceMonitor:
   # Set to true to enable the ServiceMonitor resource
   enabled: false

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -534,7 +534,7 @@ extraObjects: []
 
 # ServiceMonitor Configuration for Prometheus
 # Enabling this option will create a ServiceMonitor resource that allows Prometheus to scrape metrics from the OpenSearch service.
-# This only creates the serviceMonitor, to actually have metrics Make sure to install the prometheus-exporter plugin needed for 
+# This only creates the serviceMonitor, to actually have metrics Make sure to install the prometheus-exporter plugin needed for
 # serving metrics over the `.Values.plugins` value:
 # plugins:
 #   enabled: true

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -281,7 +281,7 @@ enableServiceLinks: true
 protocol: https
 httpPort: 9200
 transportPort: 9300
-metricsPort: 9200
+metricsPort: 9600
 httpHostPort: ""
 transportHostPort: ""
 


### PR DESCRIPTION
### Description
Trying to figure out how to expose metrics, it was obvious that there is the need of installing an additional plugin to be able to expose prometheus metrics over the serviceMonitor. Also the default port exposing the metrics is 9200 and not 9600.

This fixes the default metricsPort and adds a comment about the plugin to be used in `values.yaml`
 
### Issues Resolved
#590 
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
