### PR TITLE
fix: resolve `helm lint` errors with `extraObjects`

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.24.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Resolved `helm lint` errors with extraObjects
+### Security
+---
 ## [2.24.0]
 ### Added
 - Updated OpenSearch Dashboards appVersion to 2.17.1
@@ -412,7 +421,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.24.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.24.1...HEAD
+[2.24.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.24.0...opensearch-dashboards-2.24.1
 [2.24.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.23.0...opensearch-dashboards-2.24.0
 [2.23.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.22.0...opensearch-dashboards-2.23.0
 [2.22.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.21.1...opensearch-dashboards-2.22.0

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.24.0
+version: 2.24.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/extraManifests.yaml
+++ b/charts/opensearch-dashboards/templates/extraManifests.yaml
@@ -1,8 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
 {{- if typeIs "string" . }}
-{{- tpl . $ }}
+{{ tpl . $ }}
 {{- else }}
-{{- tpl (toYaml .) $ }}
+{{ tpl (toYaml .) $ }}
 {{- end }}
 {{ end }}

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.26.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Resolved `helm lint` errors with extraObjects
+### Security
+---
 ## [2.26.0]
 ### Added
 - Updated OpenSearch appVersion to 2.17.1
@@ -503,7 +512,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.1...HEAD
+[2.26.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.0...opensearch-2.26.1
 [2.26.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.25.0...opensearch-2.26.0
 [2.25.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.24.1...opensearch-2.25.0
 [2.24.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.24.0...opensearch-2.24.1

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.26.0
+version: 2.26.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/extraManifests.yaml
+++ b/charts/opensearch/templates/extraManifests.yaml
@@ -1,8 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
 {{- if typeIs "string" . }}
-{{- tpl . $ }}
+{{ tpl . $ }}
 {{- else }}
-{{- tpl (toYaml .) $ }}
+{{ tpl (toYaml .) $ }}
 {{- end }}
 {{ end }}


### PR DESCRIPTION
### Description
If using `extraObjects`, the generated manifest fails `helm lint` with:

```shell
[ERROR] templates/extraManifests.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: apps/v1
```

This is a known issue [1] just with the go templates used for helm lint and doesn't apply to the actual template that is applied. The fix [2] is to make the whitespace work for both commands.

[1] https://github.com/helm/helm/issues/10149
[2] https://github.com/helm/helm/issues/10149#issuecomment-929205040
 
### Issues Resolved
Resolves #606 
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
