### PR TITLE
Remove default opensearch.yml config in Values.yaml to avoid security plugin conflicts

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -531,7 +531,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 [Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.27.0...HEAD
-[2.27.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.1...opensearch-2.27.1
+[2.27.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.27.0...opensearch-2.27.1
 [2.27.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.1...opensearch-2.27.0
 [2.26.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.0...opensearch-2.26.1
 [2.26.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.25.0...opensearch-2.26.0

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -530,7 +530,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.27.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.27.1...HEAD
 [2.27.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.27.0...opensearch-2.27.1
 [2.27.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.1...opensearch-2.27.0
 [2.26.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.0...opensearch-2.26.1

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.27.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Remove default opensearch.yml config in Values.yaml to avoid security plugin conflicts
+### Security
+---
 ## [2.27.0]
 ### Added
 - Updated OpenSearch appVersion to 2.18.0
@@ -522,6 +531,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 [Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.27.0...HEAD
+[2.27.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.1...opensearch-2.27.1
 [2.27.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.1...opensearch-2.27.0
 [2.26.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.26.0...opensearch-2.26.1
 [2.26.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.25.0...opensearch-2.26.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.27.0
+version: 2.27.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/ci/ci-ingress-class-name-values.yaml
+++ b/charts/opensearch/ci/ci-ingress-class-name-values.yaml
@@ -40,58 +40,58 @@ config:
   #
   #   rootLogger.level = info
   #   rootLogger.appenderRef.console.ref = console
-  opensearch.yml: |
-    cluster.name: opensearch-cluster
-
-    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
-    network.host: 0.0.0.0
-    transport.host: localhost
-    transport.tcp.port: 9300
-
-    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
-    # discovery.type: single-node
-
-    # Start OpenSearch Security Demo Configuration
-    # WARNING: revise all the lines below before you go into production
-    plugins:
-      security:
-        ssl:
-          transport:
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-            enforce_hostname_verification: false
-          http:
-            enabled: true
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-        allow_unsafe_democertificates: true
-        allow_default_init_securityindex: true
-        authcz:
-          admin_dn:
-            - CN=kirk,OU=client,O=client,L=test,C=de
-        audit.type: internal_opensearch
-        enable_snapshot_restore_privilege: true
-        check_snapshot_restore_write_privileges: true
-        restapi:
-          roles_enabled: ["all_access", "security_rest_api_access"]
-        system_indices:
-          enabled: true
-          indices:
-            [
-              ".opendistro-alerting-config",
-              ".opendistro-alerting-alert*",
-              ".opendistro-anomaly-results*",
-              ".opendistro-anomaly-detector*",
-              ".opendistro-anomaly-checkpoints",
-              ".opendistro-anomaly-detection-state",
-              ".opendistro-reports-*",
-              ".opendistro-notifications-*",
-              ".opendistro-notebooks",
-              ".opendistro-asynchronous-search-response*",
-            ]
-    ######## End OpenSearch Security Demo Configuration ########
+  # opensearch.yml: |
+  #  cluster.name: opensearch-cluster
+  #
+  #  # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+  #  network.host: 0.0.0.0
+  #  transport.host: localhost
+  #  transport.tcp.port: 9300
+  #
+  #  # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+  #  # discovery.type: single-node
+  #
+  #  # Start OpenSearch Security Demo Configuration
+  #  # WARNING: revise all the lines below before you go into production
+  #  plugins:
+  #    security:
+  #      ssl:
+  #        transport:
+  #          pemcert_filepath: esnode.pem
+  #          pemkey_filepath: esnode-key.pem
+  #          pemtrustedcas_filepath: root-ca.pem
+  #          enforce_hostname_verification: false
+  #        http:
+  #          enabled: true
+  #          pemcert_filepath: esnode.pem
+  #          pemkey_filepath: esnode-key.pem
+  #          pemtrustedcas_filepath: root-ca.pem
+  #      allow_unsafe_democertificates: true
+  #      allow_default_init_securityindex: true
+  #      authcz:
+  #        admin_dn:
+  #          - CN=kirk,OU=client,O=client,L=test,C=de
+  #      audit.type: internal_opensearch
+  #      enable_snapshot_restore_privilege: true
+  #      check_snapshot_restore_write_privileges: true
+  #      restapi:
+  #        roles_enabled: ["all_access", "security_rest_api_access"]
+  #      system_indices:
+  #        enabled: true
+  #        indices:
+  #          [
+  #            ".opendistro-alerting-config",
+  #            ".opendistro-alerting-alert*",
+  #            ".opendistro-anomaly-results*",
+  #            ".opendistro-anomaly-detector*",
+  #            ".opendistro-anomaly-checkpoints",
+  #            ".opendistro-anomaly-detection-state",
+  #            ".opendistro-reports-*",
+  #            ".opendistro-notifications-*",
+  #            ".opendistro-notebooks",
+  #            ".opendistro-asynchronous-search-response*",
+  #          ]
+  #  ######## End OpenSearch Security Demo Configuration ########
   # log4j2.properties:
 
 # Extra environment variables to append to this nodeGroup

--- a/charts/opensearch/ci/ci-ingress-class-name-values.yaml
+++ b/charts/opensearch/ci/ci-ingress-class-name-values.yaml
@@ -40,58 +40,58 @@ config:
   #
   #   rootLogger.level = info
   #   rootLogger.appenderRef.console.ref = console
-  # opensearch.yml: |
-  #  cluster.name: opensearch-cluster
-  #
-  #  # Bind to all interfaces because we don't know what IP address Docker will assign to us.
-  #  network.host: 0.0.0.0
-  #  transport.host: localhost
-  #  transport.tcp.port: 9300
-  #
-  #  # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
-  #  # discovery.type: single-node
-  #
-  #  # Start OpenSearch Security Demo Configuration
-  #  # WARNING: revise all the lines below before you go into production
-  #  plugins:
-  #    security:
-  #      ssl:
-  #        transport:
-  #          pemcert_filepath: esnode.pem
-  #          pemkey_filepath: esnode-key.pem
-  #          pemtrustedcas_filepath: root-ca.pem
-  #          enforce_hostname_verification: false
-  #        http:
-  #          enabled: true
-  #          pemcert_filepath: esnode.pem
-  #          pemkey_filepath: esnode-key.pem
-  #          pemtrustedcas_filepath: root-ca.pem
-  #      allow_unsafe_democertificates: true
-  #      allow_default_init_securityindex: true
-  #      authcz:
-  #        admin_dn:
-  #          - CN=kirk,OU=client,O=client,L=test,C=de
-  #      audit.type: internal_opensearch
-  #      enable_snapshot_restore_privilege: true
-  #      check_snapshot_restore_write_privileges: true
-  #      restapi:
-  #        roles_enabled: ["all_access", "security_rest_api_access"]
-  #      system_indices:
-  #        enabled: true
-  #        indices:
-  #          [
-  #            ".opendistro-alerting-config",
-  #            ".opendistro-alerting-alert*",
-  #            ".opendistro-anomaly-results*",
-  #            ".opendistro-anomaly-detector*",
-  #            ".opendistro-anomaly-checkpoints",
-  #            ".opendistro-anomaly-detection-state",
-  #            ".opendistro-reports-*",
-  #            ".opendistro-notifications-*",
-  #            ".opendistro-notebooks",
-  #            ".opendistro-asynchronous-search-response*",
-  #          ]
-  #  ######## End OpenSearch Security Demo Configuration ########
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+
+    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+    network.host: 0.0.0.0
+    transport.host: localhost
+    transport.tcp.port: 9300
+
+    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+    # discovery.type: single-node
+
+    # # Start OpenSearch Security Demo Configuration
+    # # WARNING: revise all the lines below before you go into production
+    # plugins:
+    #   security:
+    #     ssl:
+    #       transport:
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #         enforce_hostname_verification: false
+    #       http:
+    #         enabled: true
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #     allow_unsafe_democertificates: true
+    #     allow_default_init_securityindex: true
+    #     authcz:
+    #       admin_dn:
+    #         - CN=kirk,OU=client,O=client,L=test,C=de
+    #     audit.type: internal_opensearch
+    #     enable_snapshot_restore_privilege: true
+    #     check_snapshot_restore_write_privileges: true
+    #     restapi:
+    #       roles_enabled: ["all_access", "security_rest_api_access"]
+    #     system_indices:
+    #       enabled: true
+    #       indices:
+    #         [
+    #           ".opendistro-alerting-config",
+    #           ".opendistro-alerting-alert*",
+    #           ".opendistro-anomaly-results*",
+    #           ".opendistro-anomaly-detector*",
+    #           ".opendistro-anomaly-checkpoints",
+    #           ".opendistro-anomaly-detection-state",
+    #           ".opendistro-reports-*",
+    #           ".opendistro-notifications-*",
+    #           ".opendistro-notebooks",
+    #           ".opendistro-asynchronous-search-response*",
+    #         ]
+    # ######## End OpenSearch Security Demo Configuration ########
   # log4j2.properties:
 
 # Extra environment variables to append to this nodeGroup

--- a/charts/opensearch/ci/ci-rbac-enabled-values.yaml
+++ b/charts/opensearch/ci/ci-rbac-enabled-values.yaml
@@ -40,58 +40,58 @@ config:
   #
   #   rootLogger.level = info
   #   rootLogger.appenderRef.console.ref = console
-  opensearch.yml: |
-    cluster.name: opensearch-cluster
-
-    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
-    network.host: 0.0.0.0
-    transport.host: localhost
-    transport.tcp.port: 9300
-
-    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
-    # discovery.type: single-node
-
-    # Start OpenSearch Security Demo Configuration
-    # WARNING: revise all the lines below before you go into production
-    plugins:
-      security:
-        ssl:
-          transport:
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-            enforce_hostname_verification: false
-          http:
-            enabled: true
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-        allow_unsafe_democertificates: true
-        allow_default_init_securityindex: true
-        authcz:
-          admin_dn:
-            - CN=kirk,OU=client,O=client,L=test,C=de
-        audit.type: internal_opensearch
-        enable_snapshot_restore_privilege: true
-        check_snapshot_restore_write_privileges: true
-        restapi:
-          roles_enabled: ["all_access", "security_rest_api_access"]
-        system_indices:
-          enabled: true
-          indices:
-            [
-              ".opendistro-alerting-config",
-              ".opendistro-alerting-alert*",
-              ".opendistro-anomaly-results*",
-              ".opendistro-anomaly-detector*",
-              ".opendistro-anomaly-checkpoints",
-              ".opendistro-anomaly-detection-state",
-              ".opendistro-reports-*",
-              ".opendistro-notifications-*",
-              ".opendistro-notebooks",
-              ".opendistro-asynchronous-search-response*",
-            ]
-    ######## End OpenSearch Security Demo Configuration ########
+  # opensearch.yml: |
+  #  cluster.name: opensearch-cluster
+  #
+  #  # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+  #  network.host: 0.0.0.0
+  #  transport.host: localhost
+  #  transport.tcp.port: 9300
+  #
+  #  # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+  #  # discovery.type: single-node
+  #
+  #  # Start OpenSearch Security Demo Configuration
+  #  # WARNING: revise all the lines below before you go into production
+  #  plugins:
+  #    security:
+  #      ssl:
+  #        transport:
+  #          pemcert_filepath: esnode.pem
+  #          pemkey_filepath: esnode-key.pem
+  #          pemtrustedcas_filepath: root-ca.pem
+  #          enforce_hostname_verification: false
+  #        http:
+  #          enabled: true
+  #          pemcert_filepath: esnode.pem
+  #          pemkey_filepath: esnode-key.pem
+  #          pemtrustedcas_filepath: root-ca.pem
+  #      allow_unsafe_democertificates: true
+  #      allow_default_init_securityindex: true
+  #      authcz:
+  #        admin_dn:
+  #          - CN=kirk,OU=client,O=client,L=test,C=de
+  #      audit.type: internal_opensearch
+  #      enable_snapshot_restore_privilege: true
+  #      check_snapshot_restore_write_privileges: true
+  #      restapi:
+  #        roles_enabled: ["all_access", "security_rest_api_access"]
+  #      system_indices:
+  #        enabled: true
+  #        indices:
+  #          [
+  #            ".opendistro-alerting-config",
+  #            ".opendistro-alerting-alert*",
+  #            ".opendistro-anomaly-results*",
+  #            ".opendistro-anomaly-detector*",
+  #            ".opendistro-anomaly-checkpoints",
+  #            ".opendistro-anomaly-detection-state",
+  #            ".opendistro-reports-*",
+  #            ".opendistro-notifications-*",
+  #            ".opendistro-notebooks",
+  #            ".opendistro-asynchronous-search-response*",
+  #          ]
+  #  ######## End OpenSearch Security Demo Configuration ########
   # log4j2.properties:
 
 # Extra environment variables to append to this nodeGroup

--- a/charts/opensearch/ci/ci-rbac-enabled-values.yaml
+++ b/charts/opensearch/ci/ci-rbac-enabled-values.yaml
@@ -40,58 +40,58 @@ config:
   #
   #   rootLogger.level = info
   #   rootLogger.appenderRef.console.ref = console
-  # opensearch.yml: |
-  #  cluster.name: opensearch-cluster
-  #
-  #  # Bind to all interfaces because we don't know what IP address Docker will assign to us.
-  #  network.host: 0.0.0.0
-  #  transport.host: localhost
-  #  transport.tcp.port: 9300
-  #
-  #  # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
-  #  # discovery.type: single-node
-  #
-  #  # Start OpenSearch Security Demo Configuration
-  #  # WARNING: revise all the lines below before you go into production
-  #  plugins:
-  #    security:
-  #      ssl:
-  #        transport:
-  #          pemcert_filepath: esnode.pem
-  #          pemkey_filepath: esnode-key.pem
-  #          pemtrustedcas_filepath: root-ca.pem
-  #          enforce_hostname_verification: false
-  #        http:
-  #          enabled: true
-  #          pemcert_filepath: esnode.pem
-  #          pemkey_filepath: esnode-key.pem
-  #          pemtrustedcas_filepath: root-ca.pem
-  #      allow_unsafe_democertificates: true
-  #      allow_default_init_securityindex: true
-  #      authcz:
-  #        admin_dn:
-  #          - CN=kirk,OU=client,O=client,L=test,C=de
-  #      audit.type: internal_opensearch
-  #      enable_snapshot_restore_privilege: true
-  #      check_snapshot_restore_write_privileges: true
-  #      restapi:
-  #        roles_enabled: ["all_access", "security_rest_api_access"]
-  #      system_indices:
-  #        enabled: true
-  #        indices:
-  #          [
-  #            ".opendistro-alerting-config",
-  #            ".opendistro-alerting-alert*",
-  #            ".opendistro-anomaly-results*",
-  #            ".opendistro-anomaly-detector*",
-  #            ".opendistro-anomaly-checkpoints",
-  #            ".opendistro-anomaly-detection-state",
-  #            ".opendistro-reports-*",
-  #            ".opendistro-notifications-*",
-  #            ".opendistro-notebooks",
-  #            ".opendistro-asynchronous-search-response*",
-  #          ]
-  #  ######## End OpenSearch Security Demo Configuration ########
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+
+    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+    network.host: 0.0.0.0
+    transport.host: localhost
+    transport.tcp.port: 9300
+
+    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+    # discovery.type: single-node
+
+    # # Start OpenSearch Security Demo Configuration
+    # # WARNING: revise all the lines below before you go into production
+    # plugins:
+    #   security:
+    #     ssl:
+    #       transport:
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #         enforce_hostname_verification: false
+    #       http:
+    #         enabled: true
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #     allow_unsafe_democertificates: true
+    #     allow_default_init_securityindex: true
+    #     authcz:
+    #       admin_dn:
+    #         - CN=kirk,OU=client,O=client,L=test,C=de
+    #     audit.type: internal_opensearch
+    #     enable_snapshot_restore_privilege: true
+    #     check_snapshot_restore_write_privileges: true
+    #     restapi:
+    #       roles_enabled: ["all_access", "security_rest_api_access"]
+    #     system_indices:
+    #       enabled: true
+    #       indices:
+    #         [
+    #           ".opendistro-alerting-config",
+    #           ".opendistro-alerting-alert*",
+    #           ".opendistro-anomaly-results*",
+    #           ".opendistro-anomaly-detector*",
+    #           ".opendistro-anomaly-checkpoints",
+    #           ".opendistro-anomaly-detection-state",
+    #           ".opendistro-reports-*",
+    #           ".opendistro-notifications-*",
+    #           ".opendistro-notebooks",
+    #           ".opendistro-asynchronous-search-response*",
+    #         ]
+    # ######## End OpenSearch Security Demo Configuration ########
   # log4j2.properties:
 
 # Extra environment variables to append to this nodeGroup

--- a/charts/opensearch/ci/ci-values.yaml
+++ b/charts/opensearch/ci/ci-values.yaml
@@ -40,58 +40,58 @@ config:
   #
   #   rootLogger.level = info
   #   rootLogger.appenderRef.console.ref = console
-  opensearch.yml: |
-    cluster.name: opensearch-cluster
-
-    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
-    network.host: 0.0.0.0
-    transport.host: localhost
-    transport.tcp.port: 9300
-
-    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
-    # discovery.type: single-node
-
-    # Start OpenSearch Security Demo Configuration
-    # WARNING: revise all the lines below before you go into production
-    plugins:
-      security:
-        ssl:
-          transport:
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-            enforce_hostname_verification: false
-          http:
-            enabled: true
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-        allow_unsafe_democertificates: true
-        allow_default_init_securityindex: true
-        authcz:
-          admin_dn:
-            - CN=kirk,OU=client,O=client,L=test,C=de
-        audit.type: internal_opensearch
-        enable_snapshot_restore_privilege: true
-        check_snapshot_restore_write_privileges: true
-        restapi:
-          roles_enabled: ["all_access", "security_rest_api_access"]
-        system_indices:
-          enabled: true
-          indices:
-            [
-              ".opendistro-alerting-config",
-              ".opendistro-alerting-alert*",
-              ".opendistro-anomaly-results*",
-              ".opendistro-anomaly-detector*",
-              ".opendistro-anomaly-checkpoints",
-              ".opendistro-anomaly-detection-state",
-              ".opendistro-reports-*",
-              ".opendistro-notifications-*",
-              ".opendistro-notebooks",
-              ".opendistro-asynchronous-search-response*",
-            ]
-    ######## End OpenSearch Security Demo Configuration ########
+  # opensearch.yml: |
+  #  cluster.name: opensearch-cluster
+  #
+  #  # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+  #  network.host: 0.0.0.0
+  #  transport.host: localhost
+  #  transport.tcp.port: 9300
+  #
+  #  # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+  #  # discovery.type: single-node
+  #
+  #  # Start OpenSearch Security Demo Configuration
+  #  # WARNING: revise all the lines below before you go into production
+  #  plugins:
+  #    security:
+  #      ssl:
+  #        transport:
+  #          pemcert_filepath: esnode.pem
+  #          pemkey_filepath: esnode-key.pem
+  #          pemtrustedcas_filepath: root-ca.pem
+  #          enforce_hostname_verification: false
+  #        http:
+  #          enabled: true
+  #          pemcert_filepath: esnode.pem
+  #          pemkey_filepath: esnode-key.pem
+  #          pemtrustedcas_filepath: root-ca.pem
+  #      allow_unsafe_democertificates: true
+  #      allow_default_init_securityindex: true
+  #      authcz:
+  #        admin_dn:
+  #          - CN=kirk,OU=client,O=client,L=test,C=de
+  #      audit.type: internal_opensearch
+  #      enable_snapshot_restore_privilege: true
+  #      check_snapshot_restore_write_privileges: true
+  #      restapi:
+  #        roles_enabled: ["all_access", "security_rest_api_access"]
+  #      system_indices:
+  #        enabled: true
+  #        indices:
+  #          [
+  #            ".opendistro-alerting-config",
+  #            ".opendistro-alerting-alert*",
+  #            ".opendistro-anomaly-results*",
+  #            ".opendistro-anomaly-detector*",
+  #            ".opendistro-anomaly-checkpoints",
+  #            ".opendistro-anomaly-detection-state",
+  #            ".opendistro-reports-*",
+  #            ".opendistro-notifications-*",
+  #            ".opendistro-notebooks",
+  #            ".opendistro-asynchronous-search-response*",
+  #          ]
+  #  ######## End OpenSearch Security Demo Configuration ########
   # log4j2.properties:
 
 # Extra environment variables to append to this nodeGroup

--- a/charts/opensearch/ci/ci-values.yaml
+++ b/charts/opensearch/ci/ci-values.yaml
@@ -40,58 +40,58 @@ config:
   #
   #   rootLogger.level = info
   #   rootLogger.appenderRef.console.ref = console
-  # opensearch.yml: |
-  #  cluster.name: opensearch-cluster
-  #
-  #  # Bind to all interfaces because we don't know what IP address Docker will assign to us.
-  #  network.host: 0.0.0.0
-  #  transport.host: localhost
-  #  transport.tcp.port: 9300
-  #
-  #  # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
-  #  # discovery.type: single-node
-  #
-  #  # Start OpenSearch Security Demo Configuration
-  #  # WARNING: revise all the lines below before you go into production
-  #  plugins:
-  #    security:
-  #      ssl:
-  #        transport:
-  #          pemcert_filepath: esnode.pem
-  #          pemkey_filepath: esnode-key.pem
-  #          pemtrustedcas_filepath: root-ca.pem
-  #          enforce_hostname_verification: false
-  #        http:
-  #          enabled: true
-  #          pemcert_filepath: esnode.pem
-  #          pemkey_filepath: esnode-key.pem
-  #          pemtrustedcas_filepath: root-ca.pem
-  #      allow_unsafe_democertificates: true
-  #      allow_default_init_securityindex: true
-  #      authcz:
-  #        admin_dn:
-  #          - CN=kirk,OU=client,O=client,L=test,C=de
-  #      audit.type: internal_opensearch
-  #      enable_snapshot_restore_privilege: true
-  #      check_snapshot_restore_write_privileges: true
-  #      restapi:
-  #        roles_enabled: ["all_access", "security_rest_api_access"]
-  #      system_indices:
-  #        enabled: true
-  #        indices:
-  #          [
-  #            ".opendistro-alerting-config",
-  #            ".opendistro-alerting-alert*",
-  #            ".opendistro-anomaly-results*",
-  #            ".opendistro-anomaly-detector*",
-  #            ".opendistro-anomaly-checkpoints",
-  #            ".opendistro-anomaly-detection-state",
-  #            ".opendistro-reports-*",
-  #            ".opendistro-notifications-*",
-  #            ".opendistro-notebooks",
-  #            ".opendistro-asynchronous-search-response*",
-  #          ]
-  #  ######## End OpenSearch Security Demo Configuration ########
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+
+    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+    network.host: 0.0.0.0
+    transport.host: localhost
+    transport.tcp.port: 9300
+
+    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+    # discovery.type: single-node
+
+    # # Start OpenSearch Security Demo Configuration
+    # # WARNING: revise all the lines below before you go into production
+    # plugins:
+    #   security:
+    #     ssl:
+    #       transport:
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #         enforce_hostname_verification: false
+    #       http:
+    #         enabled: true
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #     allow_unsafe_democertificates: true
+    #     allow_default_init_securityindex: true
+    #     authcz:
+    #       admin_dn:
+    #         - CN=kirk,OU=client,O=client,L=test,C=de
+    #     audit.type: internal_opensearch
+    #     enable_snapshot_restore_privilege: true
+    #     check_snapshot_restore_write_privileges: true
+    #     restapi:
+    #       roles_enabled: ["all_access", "security_rest_api_access"]
+    #     system_indices:
+    #       enabled: true
+    #       indices:
+    #         [
+    #           ".opendistro-alerting-config",
+    #           ".opendistro-alerting-alert*",
+    #           ".opendistro-anomaly-results*",
+    #           ".opendistro-anomaly-detector*",
+    #           ".opendistro-anomaly-checkpoints",
+    #           ".opendistro-anomaly-detection-state",
+    #           ".opendistro-reports-*",
+    #           ".opendistro-notifications-*",
+    #           ".opendistro-notebooks",
+    #           ".opendistro-asynchronous-search-response*",
+    #         ]
+    # ######## End OpenSearch Security Demo Configuration ########
   # log4j2.properties:
 
 # Extra environment variables to append to this nodeGroup

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -46,57 +46,57 @@ config:
   #
   #   rootLogger.level = info
   #   rootLogger.appenderRef.console.ref = console
-  opensearch.yml: |
-    cluster.name: opensearch-cluster
-
-    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
-    network.host: 0.0.0.0
-
-    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
-    # Implicitly done if ".singleNode" is set to "true".
-    # discovery.type: single-node
-
-    # Start OpenSearch Security Demo Configuration
-    # WARNING: revise all the lines below before you go into production
-    plugins:
-      security:
-        ssl:
-          transport:
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-            enforce_hostname_verification: false
-          http:
-            enabled: true
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-        allow_unsafe_democertificates: true
-        allow_default_init_securityindex: true
-        authcz:
-          admin_dn:
-            - CN=kirk,OU=client,O=client,L=test,C=de
-        audit.type: internal_opensearch
-        enable_snapshot_restore_privilege: true
-        check_snapshot_restore_write_privileges: true
-        restapi:
-          roles_enabled: ["all_access", "security_rest_api_access"]
-        system_indices:
-          enabled: true
-          indices:
-            [
-              ".opendistro-alerting-config",
-              ".opendistro-alerting-alert*",
-              ".opendistro-anomaly-results*",
-              ".opendistro-anomaly-detector*",
-              ".opendistro-anomaly-checkpoints",
-              ".opendistro-anomaly-detection-state",
-              ".opendistro-reports-*",
-              ".opendistro-notifications-*",
-              ".opendistro-notebooks",
-              ".opendistro-asynchronous-search-response*",
-            ]
-    ######## End OpenSearch Security Demo Configuration ########
+  #opensearch.yml: |
+  #  cluster.name: opensearch-cluster
+  #
+  #  # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+  #  network.host: 0.0.0.0
+  #
+  #  # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+  #  # Implicitly done if ".singleNode" is set to "true".
+  #  # discovery.type: single-node
+  #
+  #  # Start OpenSearch Security Demo Configuration
+  #  # WARNING: revise all the lines below before you go into production
+  #  plugins:
+  #    security:
+  #      ssl:
+  #        transport:
+  #          pemcert_filepath: esnode.pem
+  #          pemkey_filepath: esnode-key.pem
+  #          pemtrustedcas_filepath: root-ca.pem
+  #          enforce_hostname_verification: false
+  #        http:
+  #          enabled: true
+  #          pemcert_filepath: esnode.pem
+  #          pemkey_filepath: esnode-key.pem
+  #          pemtrustedcas_filepath: root-ca.pem
+  #      allow_unsafe_democertificates: true
+  #      allow_default_init_securityindex: true
+  #      authcz:
+  #        admin_dn:
+  #          - CN=kirk,OU=client,O=client,L=test,C=de
+  #      audit.type: internal_opensearch
+  #      enable_snapshot_restore_privilege: true
+  #      check_snapshot_restore_write_privileges: true
+  #      restapi:
+  #        roles_enabled: ["all_access", "security_rest_api_access"]
+  #      system_indices:
+  #        enabled: true
+  #        indices:
+  #          [
+  #            ".opendistro-alerting-config",
+  #            ".opendistro-alerting-alert*",
+  #            ".opendistro-anomaly-results*",
+  #            ".opendistro-anomaly-detector*",
+  #            ".opendistro-anomaly-checkpoints",
+  #            ".opendistro-anomaly-detection-state",
+  #            ".opendistro-reports-*",
+  #            ".opendistro-notifications-*",
+  #            ".opendistro-notebooks",
+  #            ".opendistro-asynchronous-search-response*",
+  #          ]
+  #  ######## End OpenSearch Security Demo Configuration ########
   # log4j2.properties:
 
 # Extra environment variables to append to this nodeGroup

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -46,7 +46,7 @@ config:
   #
   #   rootLogger.level = info
   #   rootLogger.appenderRef.console.ref = console
-  #opensearch.yml: |
+  # opensearch.yml: |
   #  cluster.name: opensearch-cluster
   #
   #  # Bind to all interfaces because we don't know what IP address Docker will assign to us.

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -46,57 +46,57 @@ config:
   #
   #   rootLogger.level = info
   #   rootLogger.appenderRef.console.ref = console
-  # opensearch.yml: |
-  #  cluster.name: opensearch-cluster
-  #
-  #  # Bind to all interfaces because we don't know what IP address Docker will assign to us.
-  #  network.host: 0.0.0.0
-  #
-  #  # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
-  #  # Implicitly done if ".singleNode" is set to "true".
-  #  # discovery.type: single-node
-  #
-  #  # Start OpenSearch Security Demo Configuration
-  #  # WARNING: revise all the lines below before you go into production
-  #  plugins:
-  #    security:
-  #      ssl:
-  #        transport:
-  #          pemcert_filepath: esnode.pem
-  #          pemkey_filepath: esnode-key.pem
-  #          pemtrustedcas_filepath: root-ca.pem
-  #          enforce_hostname_verification: false
-  #        http:
-  #          enabled: true
-  #          pemcert_filepath: esnode.pem
-  #          pemkey_filepath: esnode-key.pem
-  #          pemtrustedcas_filepath: root-ca.pem
-  #      allow_unsafe_democertificates: true
-  #      allow_default_init_securityindex: true
-  #      authcz:
-  #        admin_dn:
-  #          - CN=kirk,OU=client,O=client,L=test,C=de
-  #      audit.type: internal_opensearch
-  #      enable_snapshot_restore_privilege: true
-  #      check_snapshot_restore_write_privileges: true
-  #      restapi:
-  #        roles_enabled: ["all_access", "security_rest_api_access"]
-  #      system_indices:
-  #        enabled: true
-  #        indices:
-  #          [
-  #            ".opendistro-alerting-config",
-  #            ".opendistro-alerting-alert*",
-  #            ".opendistro-anomaly-results*",
-  #            ".opendistro-anomaly-detector*",
-  #            ".opendistro-anomaly-checkpoints",
-  #            ".opendistro-anomaly-detection-state",
-  #            ".opendistro-reports-*",
-  #            ".opendistro-notifications-*",
-  #            ".opendistro-notebooks",
-  #            ".opendistro-asynchronous-search-response*",
-  #          ]
-  #  ######## End OpenSearch Security Demo Configuration ########
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+
+    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+    network.host: 0.0.0.0
+
+    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+    # Implicitly done if ".singleNode" is set to "true".
+    # discovery.type: single-node
+
+    # Start OpenSearch Security Demo Configuration
+    # WARNING: revise all the lines below before you go into production
+    # plugins:
+    #   security:
+    #     ssl:
+    #       transport:
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #         enforce_hostname_verification: false
+    #       http:
+    #         enabled: true
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #     allow_unsafe_democertificates: true
+    #     allow_default_init_securityindex: true
+    #     authcz:
+    #       admin_dn:
+    #         - CN=kirk,OU=client,O=client,L=test,C=de
+    #     audit.type: internal_opensearch
+    #     enable_snapshot_restore_privilege: true
+    #     check_snapshot_restore_write_privileges: true
+    #     restapi:
+    #       roles_enabled: ["all_access", "security_rest_api_access"]
+    #     system_indices:
+    #       enabled: true
+    #       indices:
+    #         [
+    #           ".opendistro-alerting-config",
+    #           ".opendistro-alerting-alert*",
+    #           ".opendistro-anomaly-results*",
+    #           ".opendistro-anomaly-detector*",
+    #           ".opendistro-anomaly-checkpoints",
+    #           ".opendistro-anomaly-detection-state",
+    #           ".opendistro-reports-*",
+    #           ".opendistro-notifications-*",
+    #           ".opendistro-notebooks",
+    #           ".opendistro-asynchronous-search-response*",
+    #         ]
+    ######## End OpenSearch Security Demo Configuration ########
   # log4j2.properties:
 
 # Extra environment variables to append to this nodeGroup


### PR DESCRIPTION
### Description
[Describe what this change achieves.]

Remove default opensearch.yml config in Values.yaml to avoid security plugin conflicts.
Now, when setting up Opensearch with the default configuration, it installs correctly with the demo configuration.

### Issues Resolved
[List any issues this PR will resolve. You should likely open an issue if one does not already exist.]
 
Resolve https://github.com/opensearch-project/helm-charts/issues/617

### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
