### PR TITLE
feat: Add ServiceMonitor for data-prepper

### DIFF
--- a/charts/data-prepper/CHANGELOG.md
+++ b/charts/data-prepper/CHANGELOG.md
@@ -4,7 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+---
 ## [Unreleased]
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
+## [0.1.1]
+### Added
+- ServiceMonitor resource for Prometheus monitoring
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
+## [0.1.0]
+### Added
 - Create initial version of data-prepper helm chart
-
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security

--- a/charts/data-prepper/Chart.yaml
+++ b/charts/data-prepper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-prepper/README.md
+++ b/charts/data-prepper/README.md
@@ -119,6 +119,9 @@ We welcome contributions! Please read our [CONTRIBUTING.md](../../CONTRIBUTING.m
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |
+| serviceMonitor.enabled | Enables the creation of a [ServiceMonitor] resource for Prometheus monitoring. Requires the Prometheus Operator to be installed in your Kubernetes cluster. | `false` |
+| serviceMonitor.path | Path where metrics are exposed | `/metrics/sys` |
+| serviceMonitor.interval | Interval at which metrics should be scraped by Prometheus | `30s` |
 
 ## License
 

--- a/charts/data-prepper/templates/serviceMonitor.yaml
+++ b/charts/data-prepper/templates/serviceMonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "data-prepper.fullname" . }}-service-monitor
+  labels:
+    {{- include "data-prepper.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "data-prepper.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: {{ .Values.serviceMonitor.metricsPortName | default "server" }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    path: {{ .Values.serviceMonitor.path }}
+{{- end }}

--- a/charts/data-prepper/values.yaml
+++ b/charts/data-prepper/values.yaml
@@ -352,3 +352,18 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# ServiceMonitor Configuration
+# Allows Prometheus to scrape metrics from the Data Prepper server.
+serviceMonitor:
+  # Set to true to enable the ServiceMonitor resource
+  enabled: false
+
+  # HTTP path where metrics are exposed.
+  path: /metrics/sys
+
+  # Frequency at which Prometheus will scrape metrics.
+  interval: 30s
+
+  # additional labels to be added to the ServiceMonitor
+  labels: {}


### PR DESCRIPTION
### Description
Adds `ServiceMonitor` resource for monitoring with Prometheus.
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
