### PR TITLE
fix(chart/data-prepper): Be explicit when we want an empty object in pipelineConfig

### DIFF
--- a/charts/data-prepper/CHANGELOG.md
+++ b/charts/data-prepper/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1]
+### Fixed
+- Make `simple-sample-pipeline` survive helm values merge by declaring empty yaml objects explicitly
+
+## [0.1.0]
 ### Added
 - Create initial version of data-prepper helm chart
 

--- a/charts/data-prepper/Chart.yaml
+++ b/charts/data-prepper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-prepper/values.yaml
+++ b/charts/data-prepper/values.yaml
@@ -109,7 +109,7 @@ pipelineConfig:
       workers: 2      # the number of workers
       delay: 5000     # in milliseconds, how long workers wait between read attempts
       source:
-        random:
+        random: {}
       buffer:
         bounded_blocking:
           buffer_size: 1024     # max number of records the buffer accepts
@@ -118,7 +118,7 @@ pipelineConfig:
         - string_converter:
             upper_case: true
       sink:
-        - stdout:
+        - stdout: {}
 
     ## More Complex example
     # otel-logs-pipeline:
@@ -128,7 +128,7 @@ pipelineConfig:
     #     otel_logs_source:
     #       ssl: false
     #   buffer:
-    #     bounded_blocking:
+    #     bounded_blocking: {}
     #   sink:
     #     - opensearch:
     #         hosts: ["https://opensearch-cluster-master:9200"]
@@ -178,7 +178,7 @@ pipelineConfig:
     #       buffer_size: 25600 # max number of records the buffer accepts
     #       batch_size: 400 # max number of records the buffer drains after each read
     #   processor:
-    #     - otel_traces:
+    #     - otel_traces: {}
     #     - otel_trace_group:
     #         hosts: [ "https://opensearch-cluster-master:9200" ]
     #         insecure: true


### PR DESCRIPTION
### Description
Fixes helm chart bug for sample pipeline for data-prepper chart.
 
### Issues Resolved
Closes #625
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
