### PR TITLE
[opensearch/1.x] feat(opensearch): update chart to version 1.33.0 with ServiceMonitor fix

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.33.0]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Fix metricsPort and plugins usage info in values.yaml
+### Security
+---
 ## [1.32.0]
 ### Added
 ### Changed
@@ -751,7 +760,8 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.32.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.33.0...HEAD
+[1.33.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.32.0...opensearch-1.33.0
 [1.32.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.31.2...opensearch-1.32.0
 [1.31.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.31.1...opensearch-1.31.2
 [1.31.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.31.0...opensearch-1.31.1

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.32.0
+version: 1.33.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/serviceMonitor.yaml
+++ b/charts/opensearch/templates/serviceMonitor.yaml
@@ -14,7 +14,7 @@ spec:
     matchLabels:
       {{- include "opensearch.selectorLabels" . | nindent 6 }}
   endpoints:
-  - port: {{ .Values.service.metricsPortName | default "metrics" }}
+  - port: {{ .Values.service.httpPortName | default "http" }}
     interval: {{ .Values.serviceMonitor.interval }}
     path: {{ .Values.serviceMonitor.path }}
 {{- end }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -514,6 +514,12 @@ extraObjects: []
 
 # ServiceMonitor Configuration for Prometheus
 # Enabling this option will create a ServiceMonitor resource that allows Prometheus to scrape metrics from the OpenSearch service.
+# This only creates the serviceMonitor, to actually have metrics Make sure to install the prometheus-exporter plugin needed for
+# serving metrics over the `.Values.plugins` value:
+# plugins:
+#   enabled: true
+#   installList:
+#     - https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/x.x.x.x/prometheus-exporter-x.x.x.x.zip
 serviceMonitor:
   # Set to true to enable the ServiceMonitor resource
   enabled: false


### PR DESCRIPTION


### Description
Same as #593 backported to `1.x`

- Update OpenSearch Helm chart version to 1.33.0 in Chart.yaml.
- Fix ServiceMonitor to use the correct httpPortName instead of metricsPortName in serviceMonitor.yaml.
- Add usage information for metricsPort and plugins in values.yaml.
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
