### PR TITLE
feat(backport/opensearch): update chart to version 1.34.0 with serviceMon BasicAuth

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.34.0]
+### Added
+- Ability to set a basic auth configuration to the `serviceMonitor`
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.33.0]
 ### Added
 ### Changed
@@ -760,7 +769,8 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.33.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.34.0...HEAD
+[1.34.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.34.0...opensearch-1.33.0
 [1.33.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.32.0...opensearch-1.33.0
 [1.32.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.31.2...opensearch-1.32.0
 [1.31.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.31.1...opensearch-1.31.2

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.33.0
+version: 1.34.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/README.md
+++ b/charts/opensearch/README.md
@@ -126,6 +126,10 @@ helm uninstall my-release
 | `serviceMonitor.enabled` | Enables the creation of a [ServiceMonitor] resource for Prometheus monitoring. Requires the Prometheus Operator to be installed in your Kubernetes cluster. | `false` |
 | `serviceMonitor.path` | Path where metrics are exposed. Applicable only if `serviceMonitor.enabled` is set to `true`. | `/_prometheus/metrics` |
 | `serviceMonitor.interval` | Interval at which metrics should be scraped by Prometheus. Applicable only if `serviceMonitor.enabled` is set to `true`. | `10s` |
+| `serviceMonitor.basicAuth.enabled`        | Wheter or not the serviceMonitor should use basic auth | `false` |
+| `serviceMonitor.basicAuth.existingSecret` | When using basicAuth for the serviceMonitor, use an existing secret | `""` |
+| `serviceMonitor.basicAuth.username`       | Username to be used for basic auth | `""` |
+| `serviceMonitor.basicAuth.password`       | Password to be used for basic auth | `""` |
 
 [anti-affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 

--- a/charts/opensearch/templates/serviceMonitor-secret.yaml
+++ b/charts/opensearch/templates/serviceMonitor-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.serviceMonitor.enabled .Values.serviceMonitor.basicAuth.enabled (not .Values.serviceMonitor.basicAuth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "opensearch.uname" . }}-service-monitor-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opensearch.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  username: {{ .Values.serviceMonitor.basicAuth.username | b64enc | quote }}
+  password: {{ .Values.serviceMonitor.basicAuth.password | b64enc | quote }}
+{{- end }}

--- a/charts/opensearch/templates/serviceMonitor.yaml
+++ b/charts/opensearch/templates/serviceMonitor.yaml
@@ -17,4 +17,21 @@ spec:
   - port: {{ .Values.service.httpPortName | default "http" }}
     interval: {{ .Values.serviceMonitor.interval }}
     path: {{ .Values.serviceMonitor.path }}
+    {{- if .Values.serviceMonitor.basicAuth.enabled }}
+    basicAuth:
+      username:
+        {{- if .Values.serviceMonitor.basicAuth.existingSecret }}
+        name: {{ .Values.serviceMonitor.basicAuth.existingSecret }}
+        {{- else }}
+        name: {{ template "opensearch.uname" . }}-service-monitor-credentials
+        {{- end }}
+        key: username
+      password:
+        {{- if .Values.serviceMonitor.basicAuth.existingSecret }}
+        name: {{ .Values.serviceMonitor.basicAuth.existingSecret }}
+        {{- else }}
+        name: {{ template "opensearch.uname" . }}-service-monitor-credentials
+        {{- end }}
+        key: password
+    {{- end }}
 {{- end }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -536,3 +536,14 @@ serviceMonitor:
   # labels:
   #  k8s.example.com/prometheus: kube-prometheus
   labels: {}
+
+  # Basic Auth configuration for the service monitor
+  # You can either use existingSecret, which expects a secret to be already present with data.username and data.password
+  # or set the credentials over the helm values, making helm create a secret for you
+  # basicAuth:
+  #   enaled: true
+  #   existingSecret: my-secret
+  #   username:  my-username
+  #   password: my-password
+  basicAuth:
+    enabled: false


### PR DESCRIPTION


### Description

Backport of #594 
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
