### PR TITLE
[opensearch/1.x] feat(serviceMonitor): add scheme and optional tlsConfig

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [1.35.1]
+### Added
+- Added scheme for serviceMonitor and optional tlsConfig
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [1.35.0]
 ### Added
 - Added plugins.removeList to allow remove plugins
@@ -778,7 +787,8 @@ config:
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.35.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.35.1...HEAD
+[1.35.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.35.0...opensearch-1.35.1
 [1.35.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.34.0...opensearch-1.35.0
 [1.34.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.34.0...opensearch-1.33.0
 [1.33.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-1.32.0...opensearch-1.33.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.35.0
+version: 1.35.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/README.md
+++ b/charts/opensearch/README.md
@@ -130,6 +130,8 @@ helm uninstall my-release
 | `serviceMonitor.basicAuth.existingSecret` | When using basicAuth for the serviceMonitor, use an existing secret | `""` |
 | `serviceMonitor.basicAuth.username`       | Username to be used for basic auth | `""` |
 | `serviceMonitor.basicAuth.password`       | Password to be used for basic auth | `""` |
+| `serviceMonitor.scheme`                   | scheme to be used for scraping the metrics | `"http"` |
+| `serviceMonitor.tlsConfig`                | optional tlsConfig to be used for scraping | `{} |
 
 [anti-affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 

--- a/charts/opensearch/templates/serviceMonitor.yaml
+++ b/charts/opensearch/templates/serviceMonitor.yaml
@@ -17,6 +17,11 @@ spec:
   - port: {{ .Values.service.httpPortName | default "http" }}
     interval: {{ .Values.serviceMonitor.interval }}
     path: {{ .Values.serviceMonitor.path }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+    {{- with .Values.serviceMonitor.tlsConfig }}
+    tlsConfig:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- if .Values.serviceMonitor.basicAuth.enabled }}
     basicAuth:
       username:

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -530,6 +530,9 @@ serviceMonitor:
   # Ensure this matches your OpenSearch service configuration.
   path: /_prometheus/metrics
 
+  # Scheme to use for scraping.
+  scheme: http
+
   # Frequency at which Prometheus will scrape metrics.
   # Adjust based on your needs.
   interval: 10s
@@ -538,6 +541,9 @@ serviceMonitor:
   # labels:
   #  k8s.example.com/prometheus: kube-prometheus
   labels: {}
+
+  # additional tlsConfig to be added to the ServiceMonitor
+  tlsConfig: {}
 
   # Basic Auth configuration for the service monitor
   # You can either use existingSecret, which expects a secret to be already present with data.username and data.password


### PR DESCRIPTION
### Description
same as https://github.com/opensearch-project/helm-charts/pull/639 for 1.x

### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
