### PR TITLE
Ability to configure Parameterize service.protocol for opensearch-das…

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.28.1]
+### Added
+- Ability to configure Parameterize service.protocol for opensearch-dashboard
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [2.28.0]
 ### Added
 - Updated OpenSearch Dashboards appVersion to 2.19.1

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.28.0
+version: 2.28.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/README.md
+++ b/charts/opensearch-dashboards/README.md
@@ -65,6 +65,7 @@ helm uninstall my-release
 | `service.annotations` | [LoadBalancer annotations][] that Kubernetes will use for the service. This will configure load balancer if `service.type` is `LoadBalancer` | `{}` |
 | `service.headless.annotations` | Allow you to set annotations on the headless service | `{}` |
 | `service.externalTrafficPolicy` | Some cloud providers allow you to specify the [LoadBalancer externalTrafficPolicy][]. Kubernetes will use this to preserve the client source IP. This will configure load balancer if `service.type` is `LoadBalancer` | `""` |
+| `service.protocol` | The name of protocol within the service | `TCP` |
 | `service.httpPortName` | The name of the http port within the service | `http` |
 | `service.labelsHeadless` | Labels to be added to headless service | `{}` |
 | `service.labels` | Labels to be added to non-headless service | `{}` |

--- a/charts/opensearch-dashboards/templates/service.yaml
+++ b/charts/opensearch-dashboards/templates/service.yaml
@@ -33,7 +33,7 @@ spec:
 {{- if .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}
-    protocol: TCP
+    protocol: {{ .Values.service.protocol | default "TCP" }}
     name: {{ .Values.service.httpPortName | default "http" }}
     targetPort: {{ .Values.service.port }}
   - name: {{ .Values.service.metricsPortName | default "metrics" }}

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -163,6 +163,7 @@ service:
   annotations: {}
   loadBalancerSourceRanges: []
   # 0.0.0.0/0
+  # protocol: HTTP
   httpPortName: http
   metricsPortName: metrics
 


### PR DESCRIPTION
Ability to configure Parameterize service.protocol for opensearch-dashboard https://github.com/opensearch-project/helm-charts/issues/532

Description
Ability to configure Parameterize service.protocol for opensearch-dashboards

Issues Resolved
https://github.com/opensearch-project/helm-charts/issues/532

Check List
 Commits are signed per the DCO using --signoff
For any changes to files within Helm chart directories:

 Helm chart version bumped
 Helm chart CHANGELOG.md updated to reflect change
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
