### PR TITLE
updated  statefulset.yaml run containers as user

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.32.1]
+### Added
+- Modified to run as user 1000 for fsgroup-volume and the sysctl containers in statefulset.yaml
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [2.32.0]
 ### Added
 - Updated OpenSearch appVersion to 2.19.1

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.32.0
+version: 2.32.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -255,7 +255,7 @@ spec:
         args:
           - 'chown -R 1000:1000 /usr/share/opensearch/data'
         securityContext:
-          runAsUser: 0
+          runAsUser: 1000
         resources:
           {{- toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
@@ -277,7 +277,7 @@ spec:
             sysctl -w vm.max_map_count=$DESIRED
           fi
         securityContext:
-          runAsUser: 0
+          runAsUser: 1000
           privileged: true
         resources:
           {{- toYaml .Values.initResources | nindent 10 }}


### PR DESCRIPTION
Modified to run as user 1000 for fsgroup-volume and the sysctl containers in statefulset.yaml

### Description
[Describe what this change achieves.]
 
### Issues Resolved
[List any issues this PR will resolve. You should likely open an issue if one does not already exist.]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
