### PR TITLE
[backport 2.x] fix: Allow adding extra service selector labels in ServiceMonitor (#673)

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.35.0]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Allow adding extra selector labels in ServiceMonitor. See: [Issue #673](https://github.com/opensearch-project/helm-charts/issues/673)
+### Security
+---
 ## [2.34.0]
 ### Added
 - Switch 2.x.x to be released from 2.x branch
@@ -602,7 +611,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.34.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.35.0...HEAD
+[2.35.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.34.0...opensearch-2.35.0
 [2.34.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.33.0...opensearch-2.34.0
 [2.33.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.32.0...opensearch-2.33.0
 [2.32.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.31.0...opensearch-2.32.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.34.0
+version: 2.35.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/serviceMonitor.yaml
+++ b/charts/opensearch/templates/serviceMonitor.yaml
@@ -13,6 +13,9 @@ spec:
   selector:
     matchLabels:
       {{- include "opensearch.selectorLabels" . | nindent 6 }}
+      {{- with .Values.serviceMonitor.selectorLabels }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
   endpoints:
   - port: {{ .Values.service.httpPortName | default "http" }}
     interval: {{ .Values.serviceMonitor.interval }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -562,6 +562,13 @@ serviceMonitor:
   #  k8s.example.com/prometheus: kube-prometheus
   labels: {}
 
+  # additional service selector labels to be added to the ServiceMonitor
+  # (these could match extra .service.labels or .service.labelsHeadless
+  # to prevent Prometheus from unnecessarily scraping each target twice)
+  # selectorLabels:
+  #   prometheus.io/scrape: "true"
+  selectorLabels: {}
+
   # additional tlsConfig to be added to the ServiceMonitor
   tlsConfig: {}
 


### PR DESCRIPTION
### Description

Allow adding extra service selector labels in ServiceMonitor via `serviceMonitor.selectorLabels` in `values.yaml`.

### Issues Resolved

#673 - Cannot specify additional ServiceMonitor service selector label

### Check List
- [X] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [X] Helm chart version bumped
- [X] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
