### PR TITLE
[data-prepper] Support configurable secretAnnotations and extraDeploy

### DIFF
--- a/charts/data-prepper/CHANGELOG.md
+++ b/charts/data-prepper/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2]
+### Added
+- Added configurable `secretAnnotations`
+- Added configurable `extraDeploy`
+
 ## [0.3.1]
 ### Added
 - Added configurable `initContainers`
@@ -19,4 +24,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0]
 ### Added
 - Create initial version of data-prepper helm chart
-

--- a/charts/data-prepper/Chart.yaml
+++ b/charts/data-prepper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-prepper/README.md
+++ b/charts/data-prepper/README.md
@@ -1,6 +1,6 @@
 # Data Prepper Helm Chart
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
 
 A Helm chart for Data Prepper
 
@@ -83,6 +83,7 @@ We welcome contributions! Please read our [CONTRIBUTING.md](../../CONTRIBUTING.m
 | config | object | `{"data-prepper-config.yaml":"ssl: false\n# circuit_breakers:\n#   heap:\n#     usage: 2gb\n#     reset: 30s\n#     check_interval: 5s\n","log4j2-rolling.properties":"#\n# Copyright OpenSearch Contributors\n# SPDX-License-Identifier: Apache-2.0\n#\n\nstatus = error\ndest = err\nname = PropertiesConfig\n\nproperty.filename = log/data-prepper/data-prepper.log\n\nappender.console.type = Console\nappender.console.name = STDOUT\nappender.console.layout.type = PatternLayout\nappender.console.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n\n\nappender.rolling.type = RollingFile\nappender.rolling.name = RollingFile\nappender.rolling.fileName = ${filename}\nappender.rolling.filePattern = logs/data-prepper.log.%d{MM-dd-yy-HH}-%i.gz\nappender.rolling.layout.type = PatternLayout\nappender.rolling.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n\nappender.rolling.policies.type = Policies\nappender.rolling.policies.time.type = TimeBasedTriggeringPolicy\nappender.rolling.policies.time.interval = 1\nappender.rolling.policies.time.modulate = true\nappender.rolling.policies.size.type = SizeBasedTriggeringPolicy\nappender.rolling.policies.size.size=100MB\nappender.rolling.strategy.type = DefaultRolloverStrategy\nappender.rolling.strategy.max = 168\n\nrootLogger.level = warn\nrootLogger.appenderRef.stdout.ref = STDOUT\nrootLogger.appenderRef.file.ref = RollingFile\n\nlogger.pipeline.name = org.opensearch.dataprepper.pipeline\nlogger.pipeline.level = info\n\nlogger.parser.name = org.opensearch.dataprepper.parser\nlogger.parser.level = info\n\nlogger.plugins.name = org.opensearch.dataprepper.plugins\nlogger.plugins.level = info\n"}` | Data Prepper configuration |
 | config."data-prepper-config.yaml" | string | `"ssl: false\n# circuit_breakers:\n#   heap:\n#     usage: 2gb\n#     reset: 30s\n#     check_interval: 5s\n"` | Main Data Prepper configuration file content |
 | config."log4j2-rolling.properties" | string | `"#\n# Copyright OpenSearch Contributors\n# SPDX-License-Identifier: Apache-2.0\n#\n\nstatus = error\ndest = err\nname = PropertiesConfig\n\nproperty.filename = log/data-prepper/data-prepper.log\n\nappender.console.type = Console\nappender.console.name = STDOUT\nappender.console.layout.type = PatternLayout\nappender.console.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n\n\nappender.rolling.type = RollingFile\nappender.rolling.name = RollingFile\nappender.rolling.fileName = ${filename}\nappender.rolling.filePattern = logs/data-prepper.log.%d{MM-dd-yy-HH}-%i.gz\nappender.rolling.layout.type = PatternLayout\nappender.rolling.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n\nappender.rolling.policies.type = Policies\nappender.rolling.policies.time.type = TimeBasedTriggeringPolicy\nappender.rolling.policies.time.interval = 1\nappender.rolling.policies.time.modulate = true\nappender.rolling.policies.size.type = SizeBasedTriggeringPolicy\nappender.rolling.policies.size.size=100MB\nappender.rolling.strategy.type = DefaultRolloverStrategy\nappender.rolling.strategy.max = 168\n\nrootLogger.level = warn\nrootLogger.appenderRef.stdout.ref = STDOUT\nrootLogger.appenderRef.file.ref = RollingFile\n\nlogger.pipeline.name = org.opensearch.dataprepper.pipeline\nlogger.pipeline.level = info\n\nlogger.parser.name = org.opensearch.dataprepper.parser\nlogger.parser.level = info\n\nlogger.plugins.name = org.opensearch.dataprepper.plugins\nlogger.plugins.level = info\n"` | Log4j2 configuration for Data Prepper logging |
+| extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 | extraEnvs | list | `[]` | Extra environment variables to pass to the Data Prepper container |
 | fullnameOverride | string | `""` | Override the default fullname for the deployment |
 | global.dockerRegistry | string | `""` | Set if you want to change the default docker registry, e.g. a private one. |
@@ -97,17 +98,17 @@ We welcome contributions! Please read our [CONTRIBUTING.md](../../CONTRIBUTING.m
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
+| initContainers | list | `[]` | Optional list of init containers for the pod |
 | nameOverride | string | `""` | Override the default name for the deployment |
 | nodeSelector | object | `{}` |  |
-| pipelineConfig | object | (See below) | Pipeline configuration |
-| pipelineConfig.enabled | boolean | `false` | Enable inline configuration in `config` sub key. |
-| pipelineConfig.config | object | `{}` | Pipeline configuration file inline if `enabled` is set to true |
-| pipelineConfig.demoPipeline | boolean | "" | If set, a demo pipeline will be provisioned with source `random` and sink `stdout`. |
-| pipelineConfig.existingSecret | string | `""` | The name of an existing secret containing the pipeline configuration. If enabled is false existingSecret is used. The existingSecret must have a key named `pipelines.yaml`. |
-| podAnnotations | object | `{}` |  |
-| podLabels | object | `{}` |  |
+| pipelineConfig | object | `{"config":null,"demoPipeline":"","enabled":false,"existingSecret":""}` | Pipeline configuration |
+| pipelineConfig.config | string | `nil` | The configuration of the pipeline see https://opensearch.org/docs/latest/data-prepper/pipelines/pipelines/ |
+| pipelineConfig.demoPipeline | string | `""` | If 'true', a secret containing a demo pipeline configuration with random source and stdout sink will be created. If left undefined, the demo pipeline will be used only when no other pipeline is configured below |
+| pipelineConfig.enabled | bool | `false` | If enabled, a secret containing the pipeline configuration will be created based on the 'config' section below. |
+| pipelineConfig.existingSecret | string | `""` | The name of the existing secret containing the pipeline configuration. If enabled is false existingSecret is used. The existingSecret must have a key named `pipelines.yaml`. |
+| podAnnotations | object | `{}` | Annotations for pods |
+| podLabels | object | `{}` | Labels for pods |
 | podSecurityContext | object | `{}` |  |
-| initContainers | list | `[]` | Optional list of init containers for the pod | 
 | ports | list | `[{"name":"http-source","port":2021},{"name":"otel-traces","port":21890},{"name":"otel-metrics","port":21891},{"name":"otel-logs","port":21892}]` | Data Prepper ports |
 | ports[0] | object | `{"name":"http-source","port":2021}` | The port that the source is running on. Default value is 2021. Valid options are between 0 and 65535. https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/http-source/ |
 | ports[1] | object | `{"name":"otel-traces","port":21890}` | The port that the otel_trace_source source runs on. Default value is 21890. https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-trace-source/ |
@@ -115,6 +116,7 @@ We welcome contributions! Please read our [CONTRIBUTING.md](../../CONTRIBUTING.m
 | ports[3] | object | `{"name":"otel-logs","port":21892}` | Represents the port that the otel_logs_source source is running on. Default value is 21892. https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-logs-source/ |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| secretAnnotations | object | `{}` | Annotations to add to secret |
 | securityContext | object | `{}` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/data-prepper/README.md.gotmpl
+++ b/charts/data-prepper/README.md.gotmpl
@@ -35,12 +35,12 @@ helm repo update
 helm install my-data-prepper-release opensearch/data-prepper
 ```
 
-Replace my-data-prepper-release with your desired release name.
+Replace my-data-prepper-release with your desired release name. When no explicit pipeline is defined, this will configure a demo pipeline using a random source and stdout sink.
 
 ## Configuration
 
 The Data Prepper Helm chart comes with a variety of configuration options to tailor the deployment to your needs.
-The default values are specified in the [values.yaml](values.yaml) file. You can override these values by providing your own values.yaml file during installation or by specifying configuration options with --set flags.
+The default values are specified in the [values.yaml](values.yaml) file. You can override these values by providing your own `values.yaml` file during installation or by specifying configuration options with --set flags.
 
 For a detailed list of configuration options, refer to the values.yaml file or the [Data Prepper documentation](https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/configuring-data-prepper/).
 

--- a/charts/data-prepper/templates/_helpers.tpl
+++ b/charts/data-prepper/templates/_helpers.tpl
@@ -93,3 +93,14 @@ If pipelineConfig.demoPipeline is undefined, return true if no other pipeline is
 {{ false }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Renders a value that contains template.
+*/}}
+{{- define "data-prepper.render" -}}
+{{-   if typeIs "string" .value }}
+{{-     tpl .value .context }}
+{{-   else }}
+{{-     tpl (.value | toYaml) .context }}
+{{-   end }}
+{{- end -}}

--- a/charts/data-prepper/templates/extra-list.yaml
+++ b/charts/data-prepper/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "data-prepper.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/data-prepper/templates/secret.yaml
+++ b/charts/data-prepper/templates/secret.yaml
@@ -5,6 +5,11 @@ metadata:
   name: {{ include "data-prepper.fullname" . }}-pipeline
   labels:
     {{- include "data-prepper.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.secretAnnotations }}
+    {{- include "data-prepper.render" (dict "value" . "context" $)
+        | nindent 4  }}
+    {{- end }}
 type: Opaque
 stringData:
   pipelines.yaml: |

--- a/charts/data-prepper/values.yaml
+++ b/charts/data-prepper/values.yaml
@@ -8,7 +8,7 @@
 replicaCount: 1
 
 global:
-  # Set if you want to change the default docker registry, e.g. a private one.
+  # -- Set if you want to change the default docker registry, e.g. a private one.
   dockerRegistry: ""
 
 image:
@@ -30,6 +30,19 @@ fullnameOverride: ""
 extraEnvs: []
   # - name: "JAVA_OPTS"
   #   value: "-Dlog4j2.debug=true"
+
+# -- Array of extra objects to deploy with the release
+extraDeploy: []
+  # - apiVersion: v1
+  #   kind: Secret
+  #   metadata:
+  #     name: data-prepper-password
+  #     labels:
+  #       app.kubernetes.io/name: data-prepper
+  #       app.kubernetes.io/instance: data-prepper
+  #   type: Opaque
+  #   data:
+  #     password: c29tZXRoaW5nCg==
 
 # Check https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/configuring-data-prepper/
 # for more information on the configuration options
@@ -95,21 +108,21 @@ config:
 # process, and output data respectively. This flexible configuration allows for the creation of complex data processing
 # flows, including the routing of data between pipelines.
 # For detailed information on the available options and to get the most up-to-date guidance on configuring `pipeline.yaml`,
-# please consult the [OpenSearch Documentation on Pipelines](https://opensearch.org/docs/2.4/data-prepper/pipelines/pipelines/).
+# please consult the [OpenSearch Documentation on Pipelines](https://opensearch.org/docs/latest/data-prepper/pipelines/pipelines/).
 # This resource provides comprehensive examples and explanations of each component, ensuring you can tailor your Data Prepper
 # deployment to meet your specific data processing needs.
 
 # -- Pipeline configuration
 pipelineConfig:
-  # If 'true', a secret containing a demo pipeline configuration with random source and stdout sink will be created.
+  # -- If 'true', a secret containing a demo pipeline configuration with random source and stdout sink will be created.
   # If left undefined, the demo pipeline will be used only when no other pipeline is configured below
   demoPipeline: ""
   # -- The name of the existing secret containing the pipeline configuration.
   # If enabled is false existingSecret is used. The existingSecret must have a key named `pipelines.yaml`.
   existingSecret: ""
-  # If enabled, a secret containing the pipeline configuration will be created based on the 'config' section below.
+  # -- If enabled, a secret containing the pipeline configuration will be created based on the 'config' section below.
   enabled: false
-  # The configuration of the pipeline see https://opensearch.org/docs/2.4/data-prepper/pipelines/pipelines/
+  # -- The configuration of the pipeline see https://opensearch.org/docs/latest/data-prepper/pipelines/pipelines/
   config:
     ## Provide your pipeline configuration here if 'enabled' is set to true. See documentation for more advanced pipelines
     # simple-sample-pipeline:
@@ -157,7 +170,12 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- Annotations to add to secret
+secretAnnotations: {}
+
+# -- Annotations for pods
 podAnnotations: {}
+# -- Labels for pods
 podLabels: {}
 
 podSecurityContext: {}
@@ -171,6 +189,7 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# -- Optional list of init containers for the pod
 initContainers: []
 
 service:


### PR DESCRIPTION
- Added configurable `secretAnnotations`

This allow to inject external secrets inside pipelines,e.g - https://docs.opensearch.org/docs/latest/data-prepper/common-use-cases/log-analytics/ .

To pass credentials:

```
 username: "${vault:secret/data/path#property#version}"
 ${vault:secret/data/data-prepper#password#1}"
```

- Added configurable `extraDeploy`

This is convient way to define extra resources, like `existingSecret`.

### Description
[Describe what this change achieves.]
 
### Issues Resolved
[List any issues this PR will resolve. You should likely open an issue if one does not already exist.]
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
