### PR TITLE
 [Dashboards] Add support for automountServiceAccountToken

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 ### Added
+- Support for disabling automountServiceAccountToken
 ### Changed
 ### Deprecated
 ### Removed

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -8,16 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 ### Added
-- Support for disabling automountServiceAccountToken
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
 ### Security
 ---
-## [3.0.0]
+## [3.2.0]
 ### Added
-- Switch main branch to be 3.x with 3.0.0 as 1st release
+- Support for disabling automountServiceAccountToken
 ### Changed
 ### Deprecated
 ### Removed
@@ -32,7 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
+---
+## [3.0.0]
+### Added
+- Switch main branch to be 3.x with 3.0.0 as 1st release
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.1.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.2.0...HEAD
+[3.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.1.0...opensearch-dashboards-3.2.0
 [3.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.0.0...opensearch-dashboards-3.1.0
 [3.0.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-2.29.0...opensearch-dashboards-3.0.0

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 3.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.0
+version: 3.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/README.md
+++ b/charts/opensearch-dashboards/README.md
@@ -77,6 +77,7 @@ helm uninstall my-release
 | `service.ipFamilies` | Sets the preferred IP variants and in which order they are preferred, the first family you list is used for the legacy .spec.ClusterIP field, [more information on dual stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/) | `""` |
 | `service.metricsPort` | The metrics port (for Performance Analyzer) that Kubernetes will use for the service. | `9601` |
 | `service.metricsPortName` | The name of the metrics port (for Performance Analyzer) within the service | `metrics` |
+| `serviceAccount.automountServiceAccountToken` | Specifies whether the Kubernetes API token for the ServiceAccount should be automatically mounted to the pod. | `true` |
 | `tolerations` | Configurable [tolerations][] | `[]` |
 | `topologySpreadConstraints` | Configuration for pod [topologySpreadConstraints][] | `[]` |
 | `updateStrategy` | The [updateStrategy][] for the StatefulSet. By default Kubernetes will wait for the cluster to be green after upgrading each pod. Setting this to `OnDelete` will allow you to manually delete each pod during upgrades | `RollingUpdate` |

--- a/charts/opensearch-dashboards/templates/serviceaccount.yaml
+++ b/charts/opensearch-dashboards/templates/serviceaccount.yaml
@@ -10,3 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccount.automountServiceAccountToken }}
+{{- else }}
+automountServiceAccountToken: false
+{{- end -}}

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -53,6 +53,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # Controls whether the ServiceAccount API token is automatically mounted on pod
+  automountServiceAccountToken: true
 
 rbac:
   create: true


### PR DESCRIPTION
### Description
This change adds the ability to disable the automatic mounting of the serviceAccount API token to the OpenSearch
Dashboards pod. The current behavior of auto-mounting the token is maintained; however, the chart now allows
this behavior to be changed by setting the serviceAccount.automountServiceAccountToken key to 'false'. The OpenSearch
Helm chart already supports this and disabling this behavior is considered a security best practice.
 
### Issues Resolved
#682 
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
