### PR TITLE
Increase the initial delay on the live check

### DIFF
--- a/charts/data-prepper/CHANGELOG.md
+++ b/charts/data-prepper/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.2]
 ### Added
-- Increase live probe initial delay to 10s
+- Increase live probe initial delay to 30s
 
 ## [0.3.1]
 ### Added

--- a/charts/data-prepper/CHANGELOG.md
+++ b/charts/data-prepper/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2]
+### Added
+- Increase live probe initial delay to 10s
+
 ## [0.3.1]
 ### Added
 - Added configurable `initContainers`

--- a/charts/data-prepper/Chart.yaml
+++ b/charts/data-prepper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-prepper/templates/deployment.yaml
+++ b/charts/data-prepper/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
               scheme: HTTPS
               {{- end }}
             periodSeconds: 10
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             failureThreshold: 2
           readinessProbe:
             httpGet:

--- a/charts/data-prepper/templates/deployment.yaml
+++ b/charts/data-prepper/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
               scheme: HTTPS
               {{- end }}
             periodSeconds: 10
-            initialDelaySeconds: 2
+            initialDelaySeconds: 10
             failureThreshold: 2
           readinessProbe:
             httpGet:


### PR DESCRIPTION
### Description
Increase the initial delay on the live check
 
### Issues Resolved
it routinely doesn't startup fast enough to not get killed for failing live checks
 
### Check List
- [ x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ x] Helm chart version bumped
- [ x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
