### PR TITLE
Fix: Add security context to OpenSearch init containers for restricted environments

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -12,19 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
-
-- Added missing security context to configfile and keystore init containers to support restricted Kubernetes environments
-
 ### Security
-
 ---
-## [3.0.0]
+## [3.2.0]
 ### Added
 ### Changed
-- Switch main branch to be 3.x with 3.0.0 as 1st release
 ### Deprecated
 ### Removed
 ### Fixed
+- Added missing security context to configfile and keystore init containers to support restricted Kubernetes environments
 ### Security
 ---
 ## [3.1.0]
@@ -35,7 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
+---
+## [3.0.0]
+### Added
+### Changed
+- Switch main branch to be 3.x with 3.0.0 as 1st release
+### Deprecated
+### Removed
+### Fixed
+### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-3.1.0...HEAD
-[3.0.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-3.0.0...opensearch-3.1.0
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-3.2.0...HEAD
+[3.2.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-3.1.0...opensearch-3.2.0
+[3.1.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-3.0.0...opensearch-3.1.0
 [3.0.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.33.0...opensearch-3.0.0

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -12,7 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Added missing security context to configfile and keystore init containers to support restricted Kubernetes environments
+
 ### Security
+
 ---
 ## [3.0.0]
 ### Added

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.0
+version: 3.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.1
+version: 3.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -292,6 +292,8 @@ spec:
         - |
           #!/usr/bin/env bash
           cp -r /tmp/configfolder/*  /tmp/config/
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
         resources:
           {{- toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
@@ -332,6 +334,8 @@ spec:
           cp -a {{ .Values.opensearchHome }}/config/opensearch.keystore /tmp/keystore/
         env: {{ toYaml .Values.extraEnvs | nindent 10 }}
         envFrom: {{ toYaml .Values.envFrom | nindent 10 }}
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
         resources:
           {{- toYaml .Values.initResources | nindent 10 }}
         volumeMounts:


### PR DESCRIPTION
### Description
This change fixes a compatibility issue with Kubernetes environments that enforce restricted pod security standards. Previously, the OpenSearch Helm chart's configfile and keystore init containers lacked proper security context configuration, causing pod creation failures in clusters with restricted security policies.

**What this change achieves:**

- **Adds security context inheritance:** Both configfile and keystore init containers now inherit the security context from .Values.securityContext, ensuring they run with the same security constraints as the main OpenSearch container

- **Enables restricted environment compatibility:** The chart can now be deployed successfully in Kubernetes clusters with restricted pod security standards (such as Tanzu Kubernetes Grid clusters)

- **Maintains backward compatibility:** Existing deployments are unaffected, as the change only adds missing security context that should have been present

- **Improves chart portability:** Users no longer need to manually edit StatefulSet configurations to add security context for init containers

**Technical details:**

The fix applies the security context template {{ toYaml .Values.securityContext | indent 10 }} to both init containers, ensuring they inherit settings like:

- runAsNonRoot: true
- runAsUser: 1000
- capabilities.drop: ["ALL"]
- Any custom security context values defined by users

This change resolves deployment failures in environments where pod security standards require non-root execution and specific security capabilities for all containers, including init containers.
 
### Issues Resolved

- Resolves #685: OpenSearch config init container lacks security context and is therefore not created in environments with restricted pod security standards

This PR fixes the bug where the configfile and keystore init containers in the OpenSearch Helm chart were missing security context configuration, preventing pod creation in Kubernetes clusters with restricted pod security policies (such as Tanzu Kubernetes Grid clusters with policy level restricted).
 
### Check List
- [ x ] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ x ] Helm chart version bumped
- [ x ] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
