### PR TITLE
[Backport 2.x] Added missing security context to configfile and keystore init containers to support restricted Kubernetes environments

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [2.35.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Added missing security context to configfile and keystore init containers to support restricted Kubernetes environments
+### Security
+---
 ## [2.35.0]
 ### Added
 - Updated OpenSearch appVersion to 2.19.3
@@ -611,7 +620,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.35.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.35.1...HEAD
+[2.35.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.35.0...opensearch-2.35.1
 [2.35.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.34.0...opensearch-2.35.0
 [2.34.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.33.0...opensearch-2.34.0
 [2.33.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-2.32.0...opensearch-2.33.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.35.0
+version: 2.35.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -292,6 +292,8 @@ spec:
         - |
           #!/usr/bin/env bash
           cp -r /tmp/configfolder/*  /tmp/config/
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
         resources:
           {{- toYaml .Values.initResources | nindent 10 }}
         volumeMounts:
@@ -332,6 +334,8 @@ spec:
           cp -a {{ .Values.opensearchHome }}/config/opensearch.keystore /tmp/keystore/
         env: {{ toYaml .Values.extraEnvs | nindent 10 }}
         envFrom: {{ toYaml .Values.envFrom | nindent 10 }}
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
         resources:
           {{- toYaml .Values.initResources | nindent 10 }}
         volumeMounts:


### PR DESCRIPTION


### Description
[Backport 2.x] Added missing security context to configfile and keystore init containers to support restricted Kubernetes environments
 
### Issues Resolved
Backport https://github.com/opensearch-project/helm-charts/pull/688
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
