### PR TITLE
use secrets for admin password

### DIFF
--- a/charts/opensearch/templates/secret.yaml
+++ b/charts/opensearch/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if empty .Values.adminPasswordSecret}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "opensearch.uname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opensearch.labels" . | nindent 4 }}
+data:
+  adminPasssword: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -410,6 +410,16 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         env:
+        - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              {{- if empty .Values.adminPasswordSecret }}
+              name: {{ include "opensearch.fullname" . }}
+              key: adminPasssword
+              {{- else -}}
+              name: {{ .Values.adminPasswordSecret.name }}
+              key: {{ .Values.adminPasswordSecret.key }}
+              {{- end }}
         - name: node.name
           valueFrom:
             fieldRef:


### PR DESCRIPTION
### Description

use a provided secret for admin password or autogenerate one if one is not provided
 
### Issues Resolved
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ ] Helm chart version bumped
- [ ] Helm chart `CHANGELOG.md` updated to reflect change

