### PR TITLE
feat(chart/opensearch): add support for persistentVolumeClaimRetentionPolicy

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 ### Added
+- Support to set `persistentVolumeClaimRetentionPolicy`
 ### Changed
 ### Deprecated
 ### Removed

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.2
+version: 3.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.3.2"
+appVersion: "3.3.3"
 
 maintainers:
   - name: DandyDeveloper

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -55,6 +55,11 @@ spec:
       storageClassName: "{{ .Values.persistence.storageClass }}"
     {{- end }}
     {{- end }}
+  {{- if (semverCompare ">= 1.32-0" .Capabilities.KubeVersion.Version) }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistence.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistence.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -220,6 +220,12 @@ persistence:
   size: 8Gi
   annotations: {}
 
+  # This allows to automatically delete PVCs on StatefulSet deletion like described in
+  # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+
 extraVolumes: []
   # - name: extras
   #   emptyDir: {}
@@ -284,7 +290,6 @@ transportPort: 9300
 metricsPort: 9600
 httpHostPort: ""
 transportHostPort: ""
-
 
 service:
   labels: {}


### PR DESCRIPTION
### Description

This pull request adds support for the `persistentVolumeClaimRetentionPolicy` feature introduced in Kubernetes 1.32. Using thing feature users can delete `PersistentVolumeClaims` upon `StatefulSet` deletion. 

This is useful for automatic  environments that can scrapped and recreated a lot.
 
### Issues Resolved

See #713 
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
