### PR TITLE
feat(chart/opensearch-dashboards): add option enableServiceLinks, solves #715

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [3.3.1]
+### Added
+- `enableServiceLinks` added to deployment.
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [3.3.0]
 ### Added
 - Updated OpenSearch Dashboards appVersion to 3.3.0

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.0
+version: 3.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/README.md
+++ b/charts/opensearch-dashboards/README.md
@@ -39,6 +39,7 @@ helm uninstall my-release
 | :--- | :--- | :--- |
 | `envFrom` | Templatable string to be passed to the [environment from variables][] which will be appended to the `envFrom:` definition for the container | `[]` |
 | `config` | Allows you to add any config files in `/usr/share/opensearch-dashboards/` such as `opensearch_dashboards.yml`. String or map format may be used for specifying content of each configuration file. In case of string format, the whole content of the config file will be replaced by new config file value when in case of using map format content of configuration file will be a result of merge. In both cases content passed through tpl. See [values.yaml][] for an example of the formatting | `{}` |
+| `enableServiceLinks` | Set to false to disabling service links, which can cause slow pod startup times when there are many services in the current namespace. | `true` |
 | `extraContainers` | Array of extra containers | `""` |
 | `extraEnvs` | Extra environments variables to be passed to OpenSearch services | `[]` |
 | `extraInitContainers` | Array of extra init containers | `[]` |

--- a/charts/opensearch-dashboards/templates/deployment.yaml
+++ b/charts/opensearch-dashboards/templates/deployment.yaml
@@ -83,6 +83,7 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
     {{- end }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- if .Values.extraInitContainers }}
       # Currently some extra blocks accept strings
       # to continue with backwards compatibility this is being kept

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -148,6 +148,8 @@ hostAliases: []
 
 serverHost: "0.0.0.0"
 
+enableServiceLinks: true
+
 service:
   type: ClusterIP
   # The IP family and IP families options are to set the behaviour in a dual-stack environment


### PR DESCRIPTION
### Description
Adding an option `enableServiceLinks` to the values.yaml, analog to the OpenSearch-chart.
 
### Issues Resolved
#715
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
