### PR TITLE
[BugFix] Allow specifying ServiceAccountName without creating one

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [3.4.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Allow specification of ServiceAccountName for StatefulSet without creating a new ServiceAccount
+### Security
+---
 ## [3.4.0]
 ### Added
 - Updated OpenSearch appVersion to 3.4.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.4.0
+version: 3.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -89,7 +89,7 @@ spec:
       {{- if and .Values.rbac.create (eq .Values.rbac.serviceAccountName "") }}
       serviceAccountName: "{{ template "opensearch.uname" . }}"
       automountServiceAccountToken: {{ ne .Values.rbac.automountServiceAccountToken false }}
-      {{- else if and .Values.rbac.create (ne .Values.rbac.serviceAccountName "") }}
+      {{- else if ne .Values.rbac.serviceAccountName "" }}
       serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
       automountServiceAccountToken: {{ ne .Values.rbac.automountServiceAccountToken false }}
       {{- else }}


### PR DESCRIPTION
### Description
Currently, the ServiceAccountName on the StatefulSet can only be set, when the "create" flag is true. This is a contradiction to the documentation which states that "external service accounts" can be used as well.
 
### Issues Resolved
No issue exists for this Bug. I just detected it while working with the Helm Chart.
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
