### PR TITLE
Allow override of core Opensearch container env variables

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [3.4.1]
+### Added
+- envTpl values key to allow overriding core opensearch container env
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+---
 ## [3.4.0]
 ### Added
 - Updated OpenSearch appVersion to 3.4.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.4.0
+version: 3.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -410,28 +410,7 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         env:
-        - name: node.name
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        {{- if (and (has "master" .Values.roles) (not .Values.singleNode)) }}
-        - name: cluster.initial_master_nodes
-          value: "{{ template "opensearch.endpoints" . }}"
-        {{- end }}
-        - name: discovery.seed_hosts
-          value: "{{ template "opensearch.masterService" . }}-headless"
-        - name: cluster.name
-          value: "{{ .Values.clusterName }}"
-        - name: network.host
-          value: "{{ .Values.networkHost }}"
-        - name: OPENSEARCH_JAVA_OPTS
-          value: "{{ .Values.opensearchJavaOpts }}"
-        - name: node.roles
-          value: "{{ template "opensearch.roles" . }}"
-        {{- if .Values.singleNode }}
-        - name: discovery.type
-          value: "single-node"
-        {{- end }}
+{{ tpl .Values.envTpl . | indent 8 -}}
 {{- if .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 8 }}
 {{- end }}

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -99,6 +99,34 @@ config:
     ######## End OpenSearch Security Demo Configuration ########
   # log4j2.properties:
 
+# Opensearch core variables for the opensearch container (not init or any other containers)
+# This allows full override of env variables without duplicating keys in extraEnvs
+# Duplicated env keys can cause errors: https://github.com/helm/helm/issues/31529
+
+envTpl: |
+  - name: node.name
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  {{- if (and (has "master" .Values.roles) (not .Values.singleNode)) }}
+  - name: cluster.initial_master_nodes
+    value: "{{ template "opensearch.endpoints" . }}"
+  {{- end }}
+  - name: discovery.seed_hosts
+    value: "{{ template "opensearch.masterService" . }}-headless"
+  - name: cluster.name
+    value: "{{ .Values.clusterName }}"
+  - name: network.host
+    value: "{{ .Values.networkHost }}"
+  - name: OPENSEARCH_JAVA_OPTS
+    value: "{{ .Values.opensearchJavaOpts }}"
+  - name: node.roles
+    value: "{{ template "opensearch.roles" . }}"
+  {{- if .Values.singleNode }}
+  - name: discovery.type
+    value: "single-node"
+  {{- end }}
+
 # Extra environment variables to append to this nodeGroup
 # This will be appended to the current 'env:' key. You can use any of the kubernetes env
 # syntax here


### PR DESCRIPTION
### Description
Allow complete override of `env` for the opensearch container. Some users would like to customize env vars such as `node.name`.  The `extraEnvs` key is not sufficient as it can introduce [duplicate keys and patch errors with Helm v4](https://github.com/helm/helm/issues/31529 ), and is generally not a best practice.
 
### Issues Resolved
- https://github.com/opensearch-project/helm-charts/issues/721
- https://github.com/helm/helm/issues/31529 

### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
