### PR TITLE
add support for service annotations in data-prepper chart

### DIFF
--- a/charts/data-prepper/CHANGELOG.md
+++ b/charts/data-prepper/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2]
+### Added
+- Added support for service annotations
+
 ## [0.3.1]
 ### Added
 - Added configurable `initContainers`
@@ -19,4 +23,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0]
 ### Added
 - Create initial version of data-prepper helm chart
-

--- a/charts/data-prepper/Chart.yaml
+++ b/charts/data-prepper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-prepper/templates/_helpers.tpl
+++ b/charts/data-prepper/templates/_helpers.tpl
@@ -28,7 +28,7 @@ If release name contains chart name it will be used as a full name.
 Service annotations
 */}}
 {{- define "data-prepper.annotations" -}}
-{{ Values.data-prepper.service.annotations }}
+{{- toYaml .Values.service.annotations }}
 {{- end }}
 
 {{/*

--- a/charts/data-prepper/templates/_helpers.tpl
+++ b/charts/data-prepper/templates/_helpers.tpl
@@ -23,6 +23,14 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+
+{{/*
+Service annotations
+*/}}
+{{- define "data-prepper.annotations" -}}
+{{ Values.data-prepper.service.annotations }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/data-prepper/templates/service.yaml
+++ b/charts/data-prepper/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ include "data-prepper.fullname" . }}
   annotations:
-    {{- include "data-prepper.annotations"| nindent 4 }}
+    {{- include "data-prepper.annotations" . | nindent 4 }}
   labels:
     {{- include "data-prepper.labels" . | nindent 4 }}
 spec:

--- a/charts/data-prepper/templates/service.yaml
+++ b/charts/data-prepper/templates/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "data-prepper.fullname" . }}
+  annotations:
+    {{- include "data-prepper.annotations"| nindent 4 }}
   labels:
     {{- include "data-prepper.labels" . | nindent 4 }}
 spec:

--- a/charts/data-prepper/values.yaml
+++ b/charts/data-prepper/values.yaml
@@ -175,6 +175,7 @@ initContainers: []
 
 service:
   type: ClusterIP
+  annotations: {}
 
 ingress:
   enabled: false

--- a/charts/data-prepper/values.yaml
+++ b/charts/data-prepper/values.yaml
@@ -176,6 +176,7 @@ initContainers: []
 service:
   type: ClusterIP
   annotations: {}
+    # service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
 
 ingress:
   enabled: false


### PR DESCRIPTION
### Description
This pull request adds support for specifying custom annotations on the Kubernetes Service resource in the `data-prepper` Helm chart. This allows users to set service annotations (such as for cloud provider integrations) via the chart's values. The chart version is also bumped to reflect this new feature.

**Service annotation support:**
* Added a `service.annotations` field to `values.yaml` to allow users to specify custom annotations for the Service resource.
* Introduced a new Helm template helper `data-prepper.annotations` in `_helpers.tpl` to render service annotations.
* Updated the `service.yaml` template to apply the user-provided annotations to the Service metadata.

**Documentation and versioning:**
* Updated the `CHANGELOG.md` to document the new service annotation feature and incremented the chart version to `0.3.2`. 
 
### Issues Resolved
#567 
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change
