### PR TITLE
[Dashboards] Fix readOnlyRootFilesystem by adding emptyDir for data dir

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- Added emptyDir volume for /usr/share/opensearch-dashboards/data to support readOnlyRootFilesystem (issue #368)
 ### Security
 ---
 ## [3.4.0]
@@ -77,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.4.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.5.0...HEAD
+[3.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.4.0...opensearch-dashboards-3.5.0
 [3.4.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.3.0...opensearch-dashboards-3.4.0
 [3.3.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.2.2...opensearch-dashboards-3.3.0
 [3.2.2]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.2.1...opensearch-dashboards-3.2.2

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.4.0
+version: 3.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/deployment.yaml
+++ b/charts/opensearch-dashboards/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
             defaultMode: {{ .Values.opensearchDashboardsYml.defaultMode }}
             {{- end }}
         {{- end }}
+        {{- if .Values.securityContext.readOnlyRootFilesystem }}
+        - name: dashboards-data
+          emptyDir: {}
+        {{- end }}
         {{- if .Values.extraVolumes }}
         # Currently some extra blocks accept strings
         # to continue with backwards compatibility this is being kept
@@ -195,6 +199,10 @@ spec:
           - name: config
             mountPath: /usr/share/opensearch-dashboards/config/{{ $path }}
             subPath: {{ $path }}
+          {{- end }}
+          {{- if .Values.securityContext.readOnlyRootFilesystem }}
+          - name: dashboards-data
+            mountPath: /usr/share/opensearch-dashboards/data
           {{- end }}
           {{- if .Values.extraVolumeMounts }}
           # Currently some extra blocks accept strings


### PR DESCRIPTION
--                                                                                                                                                                                                                                                                    
  ## Summary                                                                                                                                                                                                                                                             
  - Fixes OpenSearch Dashboards failing to start when `securityContext.readOnlyRootFilesystem: true` is set                                                                                                                                                              
  - Adds a conditional `emptyDir` volume mounted at `/usr/share/opensearch-dashboards/data` so the UUID file can be written
  - The volume is only added when `readOnlyRootFilesystem` is enabled — no change to default behavior

  Resolves https://github.com/opensearch-project/helm-charts/issues/368

  ## Changes
  - **`charts/opensearch-dashboards/templates/deployment.yaml`** — Added conditional emptyDir volume (`dashboards-data`) and volumeMount at `/usr/share/opensearch-dashboards/data` when `.Values.securityContext.readOnlyRootFilesystem` is true
  - **`charts/opensearch-dashboards/Chart.yaml`** — Bumped chart version from 3.4.0 to 3.5.0
  - **`charts/opensearch-dashboards/CHANGELOG.md`** — Documented the fix under `[Unreleased] > Fixed`

  ## Test plan
  - [x] `helm lint` passes
  - [x] `helm template` with `readOnlyRootFilesystem=true` renders the emptyDir volume and mount correctly
  - [x] `helm template` without `readOnlyRootFilesystem` does NOT include the extra volume (no regression)
  - [x] Full E2E on kind cluster (k8s v1.27.3): deployed OpenSearch 3.4.0 single-node backend, then OpenSearch Dashboards with `readOnlyRootFilesystem=true`
    - EROFS error is **fixed** — no read-only filesystem errors in logs
    - No `ConnectionError` / `getaddrinfo EBUSY` errors — Dashboards connects to OpenSearch successfully
    - UUID file written successfully at `/usr/share/opensearch-dashboards/data/uuid`
    - Pod reaches `Ready 1/1` with zero restarts
  - [x] Default deployment (without `readOnlyRootFilesystem`) — behavior unchanged, no extra volume added