### PR TITLE
[OpenSearch] Fix readOnlyRootFilesystem by adding emptyDir volumes

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- Added emptyDir volumes for logs and /tmp to support readOnlyRootFilesystem (issue #369)
 ### Security
 ---
 ## [3.4.0]

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.4.0
+version: 3.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -227,6 +227,18 @@ spec:
         secret: {{ toYaml . | nindent 12 }}
       {{- end }}
 {{ end }}
+      {{- if .Values.securityContext.readOnlyRootFilesystem }}
+      - name: opensearch-config
+        emptyDir: {}
+      - name: opensearch-logs
+        emptyDir: {}
+      - name: opensearch-tmp
+        emptyDir: {}
+      {{- if not .Values.persistence.enabled }}
+      - name: opensearch-data
+        emptyDir: {}
+      {{- end }}
+      {{- end }}
       {{- if .Values.extraVolumes }}
       # Currently some extra blocks accept strings
       # to continue with backwards compatibility this is being kept
@@ -245,8 +257,23 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{ toYaml .Values.hostAliases | nindent 8 }}
       {{- end }}
-      {{- if or (.Values.extraInitContainers) (.Values.keystore) (.Values.persistence.enabled) (.Values.sysctlInit.enabled) (.Values.config)  }}
+      {{- if or (.Values.extraInitContainers) (.Values.keystore) (.Values.persistence.enabled) (.Values.sysctlInit.enabled) (.Values.config) (.Values.securityContext.readOnlyRootFilesystem)  }}
       initContainers:
+{{- if .Values.securityContext.readOnlyRootFilesystem }}
+      - name: config-dir-setup
+        image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        command:
+        - sh
+        - -c
+        - |
+          cp -a {{ .Values.opensearchHome }}/config/* /tmp/opensearch-config/
+        resources:
+          {{- toYaml .Values.initResources | nindent 10 }}
+        volumeMounts:
+          - mountPath: /tmp/opensearch-config/
+            name: opensearch-config
+{{- end }}
 {{- if and .Values.persistence.enabled .Values.persistence.enableInitChown }}
       - name: fsgroup-volume
         image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.persistence.image | default "busybox" }}:{{ .Values.persistence.imageTag | default "latest" }}"
@@ -512,6 +539,18 @@ spec:
           mountPath: {{ $.Values.opensearchHome }}/config/{{ $path }}
           subPath: {{ $path }}
         {{- end -}}
+        {{- if .Values.securityContext.readOnlyRootFilesystem }}
+        - name: opensearch-config
+          mountPath: {{ .Values.opensearchHome }}/config
+        - name: opensearch-logs
+          mountPath: {{ .Values.opensearchHome }}/logs
+        - name: opensearch-tmp
+          mountPath: /tmp
+        {{- if not .Values.persistence.enabled }}
+        - name: opensearch-data
+          mountPath: {{ .Values.opensearchHome }}/data
+        {{- end }}
+        {{- end }}
         {{- if .Values.extraVolumeMounts }}
         # Currently some extra blocks accept strings
         # to continue with backwards compatibility this is being kept


### PR DESCRIPTION
## Summary
- Fixes OpenSearch failing to start when `securityContext.readOnlyRootFilesystem: true` is set
- Adds conditional emptyDir volumes for config, logs, `/tmp`, and data (when persistence is disabled)
- Adds a `config-dir-setup` init container that copies the original config directory to a writable emptyDir
- Volumes are only added when `readOnlyRootFilesystem` is enabled — no change to default behavior

Resolves https://github.com/opensearch-project/helm-charts/issues/369

## Changes
- **`charts/opensearch/templates/statefulset.yaml`**:
  - Added conditional emptyDir volumes: `opensearch-config`, `opensearch-logs`, `opensearch-tmp`, and `opensearch-data` (when persistence disabled)
  - Added `config-dir-setup` init container to copy original config files to writable emptyDir
  - Updated `initContainers` condition to include `readOnlyRootFilesystem`
  - Added volumeMounts in main container for all writable paths
- **`charts/opensearch/Chart.yaml`** — Bumped chart version from 3.4.0 to 3.5.0
- **`charts/opensearch/CHANGELOG.md`** — Documented the fix under `[Unreleased] > Fixed`

## Test plan
- [x] `helm lint` passes
- [x] `helm template` with `readOnlyRootFilesystem=true` renders all emptyDir volumes, mounts, and init container
- [x] `helm template` without `readOnlyRootFilesystem` produces no extra volumes (no regression)
- [x] Full E2E on kind cluster (k8s v1.27.3): deployed OpenSearch single-node with `readOnlyRootFilesystem=true`
  - All EROFS errors are **fixed** — no read-only filesystem errors in logs
  - No `performance-analyzer.log` write failures
  - No Java `FileSystemException` / `createTempDirectory` errors
  - No `opensearch.keystore.tmp` write failures
  - Pod reaches `Ready 1/1` with zero restarts
- [x] OpenSearch Dashboards connects successfully to the readOnlyRootFilesystem-enabled OpenSearch backend