### PR TITLE
Add extraContainers support to data-prepper chart

### DIFF
--- a/charts/data-prepper/CHANGELOG.md
+++ b/charts/data-prepper/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2]
+### Added
+- Added configurable `extraContainers`
+
 ## [0.3.1]
 ### Added
 - Added configurable `initContainers`

--- a/charts/data-prepper/Chart.yaml
+++ b/charts/data-prepper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-prepper/README.md
+++ b/charts/data-prepper/README.md
@@ -124,6 +124,7 @@ We welcome contributions! Please read our [CONTRIBUTING.md](../../CONTRIBUTING.m
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |
+| extraContainers | list | `[]` | Optional list of sidecar containers which runs along the data-prepper container |
 
 ## License
 

--- a/charts/data-prepper/templates/deployment.yaml
+++ b/charts/data-prepper/templates/deployment.yaml
@@ -84,6 +84,9 @@ spec:
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }} 
       volumes:
         - name: data-prepper-config
           configMap:

--- a/charts/data-prepper/values.yaml
+++ b/charts/data-prepper/values.yaml
@@ -173,6 +173,8 @@ securityContext: {}
 
 initContainers: []
 
+extraContainers: []
+
 service:
   type: ClusterIP
 


### PR DESCRIPTION
### Description
Enables the user to set a list of extraContainers (sidecar-containers) which runs alongside with the dataprepper container and can also use volume mounts etc. to achieve common Kubernetes patterns  
 
### Issues Resolved
#729
 
### Check List
- [x ] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [ x] Helm chart version bumped
- [ x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
