### PR TITLE
Add support for gateway API #722

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 ### Added
+- Added support for gateway API (issue #722)
 ### Changed
 ### Deprecated
 ### Removed

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.5.0
+version: 3.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/NOTES.txt
+++ b/charts/opensearch-dashboards/templates/NOTES.txt
@@ -5,6 +5,14 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.gateway.enabled }}
+{{- if .Values.gateway.hostnames }}
+{{- range .Values.gateway.hostnames }}
+  https://{{ . }}
+{{- end }}
+{{- else }}
+  HTTPRoute attached to gateway(s): {{ range .Values.gateway.parentRefs }}{{ .name }}{{ if .namespace }}.{{ .namespace }}{{ end }} {{ end }}
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "opensearch-dashboards.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/opensearch-dashboards/templates/httproute.yaml
+++ b/charts/opensearch-dashboards/templates/httproute.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "opensearch-dashboards.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "opensearch-dashboards.labels" . | nindent 4 }}
+    {{- with .Values.gateway.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- range .Values.gateway.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+      {{- if .port }}
+      port: {{ .port }}
+      {{- end }}
+    {{- end }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.gateway.rules }}
+    {{- range .Values.gateway.rules }}
+    - matches:
+        {{- range .matches }}
+        - path:
+            type: {{ .path.type | default "PathPrefix" }}
+            value: {{ .path.value | default "/" }}
+        {{- end }}
+      backendRefs:
+        {{- if .backendRefs }}
+        {{- toYaml .backendRefs | nindent 8 }}
+        {{- else }}
+        - name: {{ $fullName }}
+          port: {{ $servicePort }}
+        {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $servicePort }}
+    {{- end }}
+{{- end }}
+

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -189,6 +189,29 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+gateway:
+  enabled: false
+  annotations: {}
+  labels: {}
+  # parentRefs defines the Gateway(s) this HTTPRoute should attach to.
+  # To enable TLS, reference a listener with sectionName pointing to an HTTPS listener on your Gateway.
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-namespace
+  #    sectionName: https   # Reference an HTTPS listener for TLS termination
+  #    port: 443
+  # hostnames restricts the HTTPRoute to requests matching these hostnames.
+  hostnames: []
+  #  - chart-example.local
+  # rules defines the routing rules. If empty, all traffic is forwarded to the service on service.port (5601).
+  rules: []
+  #  - matches:
+  #      - path:
+  #          type: PathPrefix
+  #          value: /
+  #    backendRefs: []   # Defaults to the opensearch-dashboards service on service.port (5601)
+  #    filters: []
+
 resources:
   requests:
     cpu: "100m"

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 ### Added
+- Added support for gateway API (issue #722)
 ### Changed
 ### Deprecated
 ### Removed

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.5.0
+version: 3.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/httproute.yaml
+++ b/charts/opensearch/templates/httproute.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "opensearch.serviceName" . -}}
+{{- $servicePort := .Values.httpPort -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "opensearch.labels" . | nindent 4 }}
+    {{- with .Values.gateway.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- range .Values.gateway.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+      {{- if .port }}
+      port: {{ .port }}
+      {{- end }}
+    {{- end }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.gateway.rules }}
+    {{- range .Values.gateway.rules }}
+    - matches:
+        {{- range .matches }}
+        - path:
+            type: {{ .path.type | default "PathPrefix" }}
+            value: {{ .path.value | default "/" }}
+        {{- end }}
+      backendRefs:
+        {{- if .backendRefs }}
+        {{- toYaml .backendRefs | nindent 8 }}
+        {{- else }}
+        - name: {{ $fullName }}
+          port: {{ $servicePort }}
+        {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $servicePort }}
+    {{- end }}
+{{- end }}
+

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -418,6 +418,29 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+gateway:
+  enabled: false
+  annotations: {}
+  labels: {}
+  # parentRefs defines the Gateway(s) this HTTPRoute should attach to.
+  # To enable TLS, reference a listener with sectionName pointing to an HTTPS listener on your Gateway.
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-namespace
+  #    sectionName: https   # Reference an HTTPS listener for TLS termination
+  #    port: 443
+  # hostnames restricts the HTTPRoute to requests matching these hostnames.
+  hostnames: []
+  #  - chart-example.local
+  # rules defines the routing rules. If empty, all traffic is forwarded to the service on httpPort.
+  rules: []
+  #  - matches:
+  #      - path:
+  #          type: PathPrefix
+  #          value: /
+  #    backendRefs: []   # Defaults to the opensearch service on httpPort (9200)
+  #    filters: []
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
### Description
This PR add support for Gateway API in Kubernetes for the charts `opensearch` and `opensearch-dashboard`
 
### Issues Resolved
- [Enhancement][Opensearch] Add support for Gateway API #722 
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
