### PR TITLE
Fix probe handler overrides in chart templates

### DIFF
--- a/charts/opensearch-dashboards/templates/_helpers.tpl
+++ b/charts/opensearch-dashboards/templates/_helpers.tpl
@@ -101,3 +101,26 @@ Return if ingress supports ingressClassName.
 {{- define "opensearch-dashboards.ingress.supportsIngressClassName" -}}
   {{- or (eq (include "opensearch-dashboards.ingress.isStable" .) "true") (and (eq (include "opensearch-dashboards.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
 {{- end -}}
+
+{{/*
+Render a probe with exactly one handler.
+This allows users to override the default tcpSocket probe with exec/httpGet/grpc
+without inheriting multiple handlers through Helm values merging.
+*/}}
+{{- define "opensearch-dashboards.probe" -}}
+{{- $probe := . -}}
+{{- $rendered := dict -}}
+{{- if hasKey $probe "exec" -}}
+{{- $_ := set $rendered "exec" (get $probe "exec") -}}
+{{- else if hasKey $probe "httpGet" -}}
+{{- $_ := set $rendered "httpGet" (get $probe "httpGet") -}}
+{{- else if hasKey $probe "tcpSocket" -}}
+{{- $_ := set $rendered "tcpSocket" (get $probe "tcpSocket") -}}
+{{- else if hasKey $probe "grpc" -}}
+{{- $_ := set $rendered "grpc" (get $probe "grpc") -}}
+{{- end -}}
+{{- range $key, $value := omit $probe "exec" "httpGet" "tcpSocket" "grpc" -}}
+{{- $_ := set $rendered $key $value -}}
+{{- end -}}
+{{- toYaml $rendered -}}
+{{- end -}}

--- a/charts/opensearch-dashboards/templates/deployment.yaml
+++ b/charts/opensearch-dashboards/templates/deployment.yaml
@@ -102,17 +102,15 @@ spec:
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         {{- if .Values.readinessProbe }}
         readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 10 }}
+{{ include "opensearch-dashboards.probe" .Values.readinessProbe | indent 10 }}
         {{- end }}
         {{- if .Values.livenessProbe }}
         livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 10 }}
+{{ include "opensearch-dashboards.probe" .Values.livenessProbe | indent 10 }}
         {{- end }}
-        {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.Version }}
-        {{- if .Values.readinessProbe }}
+        {{- if and (semverCompare ">=1.16-0" .Capabilities.KubeVersion.Version) .Values.startupProbe }}
         startupProbe:
-{{ toYaml .Values.startupProbe | indent 10 }}
-        {{- end }}
+{{ include "opensearch-dashboards.probe" .Values.startupProbe | indent 10 }}
         {{- end }}
         env:
         {{- if .Values.opensearchURL }}

--- a/charts/opensearch/templates/_helpers.tpl
+++ b/charts/opensearch/templates/_helpers.tpl
@@ -142,3 +142,26 @@ Return if ingress supports ingressClassName.
 {{- define "opensearch.ingress.supportsIngressClassName" -}}
   {{- or (eq (include "opensearch.ingress.isStable" .) "true") (and (eq (include "opensearch.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
 {{- end -}}
+
+{{/*
+Render a probe with exactly one handler.
+This allows users to override the default tcpSocket probe with exec/httpGet/grpc
+without inheriting multiple handlers through Helm values merging.
+*/}}
+{{- define "opensearch.probe" -}}
+{{- $probe := . -}}
+{{- $rendered := dict -}}
+{{- if hasKey $probe "exec" -}}
+{{- $_ := set $rendered "exec" (get $probe "exec") -}}
+{{- else if hasKey $probe "httpGet" -}}
+{{- $_ := set $rendered "httpGet" (get $probe "httpGet") -}}
+{{- else if hasKey $probe "tcpSocket" -}}
+{{- $_ := set $rendered "tcpSocket" (get $probe "tcpSocket") -}}
+{{- else if hasKey $probe "grpc" -}}
+{{- $_ := set $rendered "grpc" (get $probe "grpc") -}}
+{{- end -}}
+{{- range $key, $value := omit $probe "exec" "httpGet" "tcpSocket" "grpc" -}}
+{{- $_ := set $rendered $key $value -}}
+{{- end -}}
+{{- toYaml $rendered -}}
+{{- end -}}

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -384,15 +384,17 @@ spec:
 
         image: "{{ template "opensearch.dockerRegistry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        {{- if .Values.readinessProbe }}
         readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 10 }}
+{{ include "opensearch.probe" .Values.readinessProbe | indent 10 }}
+        {{- end }}
         {{- if .Values.livenessProbe }}
         livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 10 }}
+{{ include "opensearch.probe" .Values.livenessProbe | indent 10 }}
         {{- end }}
-      {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.Version }}
+      {{- if and (semverCompare ">=1.16-0" .Capabilities.KubeVersion.Version) .Values.startupProbe }}
         startupProbe:
-{{ toYaml .Values.startupProbe | indent 10 }}
+{{ include "opensearch.probe" .Values.startupProbe | indent 10 }}
       {{- end }}
         ports:
         - name: http


### PR DESCRIPTION
## Summary
- fix `opensearch` and `opensearch-dashboards` probe rendering so users can override the default handler (`tcpSocket`) with `exec`, `httpGet`, or `grpc` without ending up with multiple handlers in the rendered manifest
- keep the change minimal and backwards-compatible by preserving existing probe timing/threshold fields and only normalizing the handler section during template rendering
- render `startupProbe` only when it is configured, matching the existing optional behavior used for the other probes

## Why
A few users have hit Helm values merge behavior here: if the chart defines a default `tcpSocket` probe and the user overrides it with `exec` or `httpGet`, Helm merges maps rather than replacing them. That leaves both handlers in the final manifest, which Kubernetes rejects.

This affects the `opensearch` chart today and the same pattern exists in `opensearch-dashboards` as well.

This PR addresses that in the templates instead of forcing users to rely on post-renderers or patching generated manifests.

## Implementation details
I added a small helper in each chart that renders exactly one probe handler with the following precedence:
1. `exec`
2. `httpGet`
3. `tcpSocket`
4. `grpc`

All non-handler fields (for example `initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, `failureThreshold`, `successThreshold`) are preserved as-is.

This keeps default behavior unchanged while making overrides work as users expect.

## Validation
I validated this locally by rendering both charts with Helm and overriding the default probe handler.

For example, this previously produced an invalid manifest because the default `tcpSocket` handler was merged with `exec`:

```yaml
startupProbe:
  exec:
    command:
      - sh
      - -c
      - exit 0
  initialDelaySeconds: 60
```

And this previously inherited the default `tcpSocket` handler instead of cleanly switching to `httpGet`:

```yaml
readinessProbe:
  httpGet:
    path: /
    port: 9200
    scheme: HTTP
  periodSeconds: 7
```

After this change, both render cleanly with a single handler.

I also tested the patched chart in a dev cluster with TLS and the security plugin enabled using exec-based HTTPS probes similar to the following:

```yaml
extraEnvs:
  - name: OPENSEARCH_USERNAME
    valueFrom:
      secretKeyRef:
        name: opensearch-logs-admin
        key: username
  - name: OPENSEARCH_PASSWORD
    valueFrom:
      secretKeyRef:
        name: opensearch-logs-admin
        key: password

startupProbe:
  exec:
    command:
      - bash
      - -ec
      - |
        curl --silent --fail --insecure \
          -u "${OPENSEARCH_USERNAME}:${OPENSEARCH_PASSWORD}" \
          https://127.0.0.1:9200/_cluster/health?local=true >/dev/null
  initialDelaySeconds: 10
  periodSeconds: 10
  timeoutSeconds: 5
  failureThreshold: 60

readinessProbe:
  exec:
    command:
      - bash
      - -ec
      - |
        curl --silent --fail --insecure \
          -u "${OPENSEARCH_USERNAME}:${OPENSEARCH_PASSWORD}" \
          "https://127.0.0.1:9200/_cluster/health?local=true&wait_for_status=yellow&timeout=2s" >/dev/null
  periodSeconds: 10
  timeoutSeconds: 5
  failureThreshold: 3

livenessProbe:
  exec:
    command:
      - bash
      - -ec
      - |
        curl --silent --fail --insecure \
          -u "${OPENSEARCH_USERNAME}:${OPENSEARCH_PASSWORD}" \
          https://127.0.0.1:9200/ >/dev/null
  periodSeconds: 20
  timeoutSeconds: 5
  failureThreshold: 5
```

That rollout completed successfully, the cluster became green, and the rendered probes in the live workload contained only the configured `exec` handlers.

## Related context
- fixes the core issue reported in #703 for `opensearch`
- applies the same fix to `opensearch-dashboards`, which follows the same rendering pattern

Happy to adjust the helper or scope if maintainers would prefer this to be limited to one chart first.
