### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/github-merit-badger.yml
+++ b/.github/workflows/github-merit-badger.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: aws-github-ops/github-merit-badger@v0.0.98
+      - uses: aws-github-ops/github-merit-badger@949750c3f54985fad4715e77f88942be7547f1bc # v0.0.98
         id: merit-badger
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Pin all GitHub Action tag references to their corresponding commit SHAs.

Tags are mutable references that can be force-pushed to point to different commits, making them vulnerable to supply chain attacks. Commit SHAs are immutable and guarantee that the exact reviewed code is executed in CI workflows. This change pins all third-party actions to their current commit SHAs to prevent potential tampering.