### PR TITLE
Add optional headless service to data-prepper chart

### DIFF
--- a/charts/data-prepper/CHANGELOG.md
+++ b/charts/data-prepper/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0]
+### Added
+- Added `service.headless` to optionally deploy the service as headless (`clusterIP: None`)
+
 ## [0.3.1]
 ### Added
 - Added configurable `initContainers`

--- a/charts/data-prepper/Chart.yaml
+++ b/charts/data-prepper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-prepper/README.md
+++ b/charts/data-prepper/README.md
@@ -116,6 +116,7 @@ We welcome contributions! Please read our [CONTRIBUTING.md](../../CONTRIBUTING.m
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
+| service.headless | bool | `false` | If true, the service is deployed as headless (`clusterIP: None`). Requires `service.type` to be `ClusterIP`. |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |

--- a/charts/data-prepper/templates/service.yaml
+++ b/charts/data-prepper/templates/service.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.service.headless (ne .Values.service.type "ClusterIP") }}
+{{- fail "service.headless can only be enabled when service.type is ClusterIP" }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,6 +9,9 @@ metadata:
     {{- include "data-prepper.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.headless }}
+  clusterIP: None
+  {{- end }}
   ports:
   {{- range .Values.ports }}
     - name: {{ .name }}

--- a/charts/data-prepper/values.yaml
+++ b/charts/data-prepper/values.yaml
@@ -174,7 +174,11 @@ securityContext: {}
 initContainers: []
 
 service:
+  # -- Kubernetes service type. Must be `ClusterIP` when `service.headless` is true.
   type: ClusterIP
+  # -- If true, the service is deployed as headless (`clusterIP: None`), exposing
+  # individual pod DNS records instead of a single virtual IP. Requires `service.type` to be `ClusterIP`.
+  headless: false
 
 ingress:
   enabled: false


### PR DESCRIPTION
Adds an opt-in `service.headless` value to the data-prepper chart. When `true`, the Service is rendered as headless (`clusterIP: None`) for per-pod DNS instead of a single virtual IP. Defaults to `false`, so existing installs are unchanged.
Rather than adding a second Service, it flips the existing one to headless (headless is
just a mode of a ClusterIP Service). Since headless can't be `LoadBalancer`/`NodePort`, rendering fails with a clear error if enabled with a non-`ClusterIP` `service.type`.

### Description
[Describe what this change achieves.]
 
### Issues Resolved
Resolves #750
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
