### PR TITLE
feat(chart/opensearch): add support for persistentVolumeClaimRetentio…

### DIFF
--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [3.7.1]
+### Added
+- Support for configuring `persistentVolumeClaimRetentionPolicy` on the OpenSearch StatefulSet (Kubernetes >= 1.27; defaults to `Retain`/`Retain`)
+---
 ## [3.7.0]
 ### Added
 - Updated OpenSearch appVersion to 3.7.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.7.0
+version: 3.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -55,6 +55,11 @@ spec:
       storageClassName: "{{ .Values.persistence.storageClass }}"
     {{- end }}
     {{- end }}
+  {{- if semverCompare ">=1.27-0" .Capabilities.KubeVersion.Version }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistence.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistence.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/charts/opensearch/values.yaml
+++ b/charts/opensearch/values.yaml
@@ -220,6 +220,15 @@ persistence:
   size: 8Gi
   annotations: {}
 
+  # Controls whether the StatefulSet's PVCs are deleted or retained when the
+  # StatefulSet is deleted (whenDeleted) or scaled down (whenScaled). See
+  # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+  # Only rendered on Kubernetes >= 1.27 (feature is enabled by default from then).
+  # Defaults to Retain/Retain to preserve the previous behavior.
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+
 extraVolumes: []
   # - name: extras
   #   emptyDir: {}


### PR DESCRIPTION
### Description
Adds support for configuring the OpenSearch StatefulSet's `persistentVolumeClaimRetentionPolicy`, so PVCs created from `volumeClaimTemplates` can be automatically deleted when the StatefulSet is deleted (`whenDeleted`) or scaled down (`whenScaled`). See the [Kubernetes docs](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention).

A new `persistence.persistentVolumeClaimRetentionPolicy` value is introduced, defaulting to `Retain`/`Retain` so existing installations are unaffected. The field is only rendered on Kubernetes >= 1.27, where the `StatefulSetAutoDeletePVC` feature is enabled by default.

This reapplies #714 (by @foosinn-tio) on top of the current chart (3.7.0), with two corrections:
- Version gate changed from `>= 1.32` to `>= 1.27` — the feature is beta and on by default from 1.27, so gating at 1.32 would hide it from 1.27–1.31 clusters where it already works.
- Bumps the chart `version` only (3.7.0 → 3.7.1), leaving `appVersion` untouched, to match the repo convention (e.g. #688).

Verified with `helm lint` and `helm template`:
- k8s 1.27, defaults: renders `Retain`/`Retain`
- k8s 1.26 → block omitted (gate)
- custom values: renders `Delete`/`Delete`
- `persistence.enabled=false`:  block omitted

Credit to @foosinn-tio, the original author of #714 (retained via `Co-authored-by`).

### Issues Resolved
Closes #713
Supersedes #714

### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change