### PR TITLE
Handle release namespace

### DIFF
--- a/charts/data-prepper/CHANGELOG.md
+++ b/charts/data-prepper/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2]
+### Fixed
+- Set `metadata.namespace` explicitly on namespaced resources for Kustomization v5.8.0 compatibility
+
 ## [0.3.1]
 ### Added
 - Added configurable `initContainers`

--- a/charts/data-prepper/Chart.yaml
+++ b/charts/data-prepper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/data-prepper/templates/configmap.yaml
+++ b/charts/data-prepper/templates/configmap.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ include "data-prepper.fullname" . }}-config
   labels:
     {{- include "data-prepper.labels" . | nindent 4 }}

--- a/charts/data-prepper/templates/demoPipeline.yaml
+++ b/charts/data-prepper/templates/demoPipeline.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ include "data-prepper.fullname" . }}-demo-pipeline
   labels:
     {{- include "data-prepper.labels" . | nindent 4 }}

--- a/charts/data-prepper/templates/deployment.yaml
+++ b/charts/data-prepper/templates/deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ include "data-prepper.fullname" . }}
   labels:
     {{- include "data-prepper.labels" . | nindent 4 }}

--- a/charts/data-prepper/templates/hpa.yaml
+++ b/charts/data-prepper/templates/hpa.yaml
@@ -2,6 +2,7 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ include "data-prepper.fullname" . }}
   labels:
     {{- include "data-prepper.labels" . | nindent 4 }}

--- a/charts/data-prepper/templates/ingress.yaml
+++ b/charts/data-prepper/templates/ingress.yaml
@@ -15,6 +15,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ $fullName }}
   labels:
     {{- include "data-prepper.labels" . | nindent 4 }}

--- a/charts/data-prepper/templates/secret.yaml
+++ b/charts/data-prepper/templates/secret.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ include "data-prepper.fullname" . }}-pipeline
   labels:
     {{- include "data-prepper.labels" . | nindent 4 }}

--- a/charts/data-prepper/templates/service.yaml
+++ b/charts/data-prepper/templates/service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ include "data-prepper.fullname" . }}
   labels:
     {{- include "data-prepper.labels" . | nindent 4 }}

--- a/charts/data-prepper/templates/serviceaccount.yaml
+++ b/charts/data-prepper/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ include "data-prepper.serviceAccountName" . }}
   labels:
     {{- include "data-prepper.labels" . | nindent 4 }}

--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [3.7.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Set `metadata.namespace` explicitly on namespaced resources for Kustomization v5.8.0 compatibility
+### Security
+---
 ## [3.7.0]
 ### Added
 - Updated OpenSearch Dashboards appVersion to 3.7.0
@@ -104,7 +113,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.7.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.7.1...HEAD
+[3.7.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.7.0...opensearch-dashboards-3.7.1
 [3.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.6.0...opensearch-dashboards-3.7.0
 [3.6.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.5.0...opensearch-dashboards-3.6.0
 [3.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-dashboards-3.4.0...opensearch-dashboards-3.5.0

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.7.0
+version: 3.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/autoscaler.yaml
+++ b/charts/opensearch-dashboards/templates/autoscaler.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "opensearch-dashboards.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "opensearch-dashboards.fullname" . }}-hpa
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "opensearch-dashboards.labels" . | nindent 4 }}
 spec:
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/charts/opensearch-dashboards/templates/configmap.yaml
+++ b/charts/opensearch-dashboards/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "opensearch-dashboards.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "opensearch-dashboards.labels" . | nindent 4 }}
 data:
 {{- range $configName, $configYaml := .Values.config }}

--- a/charts/opensearch-dashboards/templates/deployment.yaml
+++ b/charts/opensearch-dashboards/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "opensearch-dashboards.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "opensearch-dashboards.labels" . | nindent 4 }}
   {{- with .Values.dashboardAnnotations }}
   annotations:

--- a/charts/opensearch-dashboards/templates/ingress.yaml
+++ b/charts/opensearch-dashboards/templates/ingress.yaml
@@ -13,6 +13,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch-dashboards.labels" . | nindent 4 }}
     {{- with .Values.ingress.labels }}

--- a/charts/opensearch-dashboards/templates/rolebinding.yaml
+++ b/charts/opensearch-dashboards/templates/rolebinding.yaml
@@ -4,6 +4,7 @@ kind: RoleBinding
 metadata:
   labels: {{- include "opensearch-dashboards.labels" . | nindent 4 }}
   name: {{ template "opensearch-dashboards.fullname" . }}-dashboards-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ template "opensearch-dashboards.serviceAccountName" . }}

--- a/charts/opensearch-dashboards/templates/service.yaml
+++ b/charts/opensearch-dashboards/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "opensearch-dashboards.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "opensearch-dashboards.labels" . | nindent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4}}

--- a/charts/opensearch-dashboards/templates/serviceaccount.yaml
+++ b/charts/opensearch-dashboards/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "opensearch-dashboards.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch-dashboards.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/opensearch/CHANGELOG.md
+++ b/charts/opensearch/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 ---
+## [3.7.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Set `metadata.namespace` explicitly on namespaced resources for Kustomization v5.8.0 compatibility
+### Security
+---
 ## [3.7.0]
 ### Added
 - Updated OpenSearch appVersion to 3.7.0
@@ -113,7 +122,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-3.7.0...HEAD
+[Unreleased]: https://github.com/opensearch-project/helm-charts/compare/opensearch-3.7.1...HEAD
+[3.7.1]: https://github.com/opensearch-project/helm-charts/compare/opensearch-3.7.0...opensearch-3.7.1
 [3.7.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-3.6.0...opensearch-3.7.0
 [3.6.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-3.5.0...opensearch-3.6.0
 [3.5.0]: https://github.com/opensearch-project/helm-charts/compare/opensearch-3.4.0...opensearch-3.5.0

--- a/charts/opensearch/Chart.yaml
+++ b/charts/opensearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.7.0
+version: 3.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch/templates/configmap.yaml
+++ b/charts/opensearch/templates/configmap.yaml
@@ -3,6 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ template "opensearch.uname" . }}-config
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}

--- a/charts/opensearch/templates/ingress.yaml
+++ b/charts/opensearch/templates/ingress.yaml
@@ -14,6 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
     {{- with .Values.ingress.ingressLabels }}

--- a/charts/opensearch/templates/networkpolicy.yaml
+++ b/charts/opensearch/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "opensearch.uname" . }}-opensearch-net
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:

--- a/charts/opensearch/templates/poddisruptionbudget.yaml
+++ b/charts/opensearch/templates/poddisruptionbudget.yaml
@@ -7,6 +7,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "opensearch.uname" . }}-pdb"
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:

--- a/charts/opensearch/templates/role.yaml
+++ b/charts/opensearch/templates/role.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $fullName | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 rules:

--- a/charts/opensearch/templates/rolebinding.yaml
+++ b/charts/opensearch/templates/rolebinding.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $fullName | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 subjects:

--- a/charts/opensearch/templates/service.yaml
+++ b/charts/opensearch/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ template "opensearch.serviceName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 {{- if .Values.service.labels }}
@@ -50,6 +51,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ template "opensearch.serviceName" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 {{- if .Values.service.labelsHeadless }}

--- a/charts/opensearch/templates/serviceaccount.yaml
+++ b/charts/opensearch/templates/serviceaccount.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- else }}
   name: {{ .Values.rbac.serviceAccountName | quote }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
   annotations:

--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "opensearch.uname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
### Description
Fix charts for kustomization v5.8.0
 
### Issues Resolved
namespace is not set on Kubernetes resources since v5.8.0.

###
For reference:
https://github.com/kubernetes-sigs/kustomize/issues/6058
 